### PR TITLE
Use `Retired` event for Toucan retirements

### DIFF
--- a/polygon-bridged-carbon/src/ToucanCarbonOffsets.ts
+++ b/polygon-bridged-carbon/src/ToucanCarbonOffsets.ts
@@ -1,6 +1,6 @@
 import { Address } from '@graphprotocol/graph-ts'
 
-import { Transfer, ToucanCarbonOffsets } from '../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets'
+import { Transfer, ToucanCarbonOffsets, Retired } from '../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets'
 
 import { toDecimal } from '../../lib/utils/Decimals'
 import { loadOrCreateCarbonOffset } from './utils/CarbonOffsets'
@@ -30,24 +30,28 @@ export function handleTransfer(event: Transfer): void {
     //carbonOffset.bridges.push(bridge.id)
   }
 
-  // Handle Retirements
-  if (event.params.to == Address.fromString('0x0000000000000000000000000000000000000000')) {
-    // This is a temporary solution - we are not tracking retirements related to HFC-23 Credits
-    // What needs to be done is to track Retire events instead of Transfer
-    if (carbonOffset.methodology != 'AM0001') {
-      let retire = loadOrCreateRetire(carbonOffset, transaction)
-      retire.value = toDecimal(event.params.value, 18)
-      retire.retiree = event.params.from.toHexString()
-
-      retire.save()
-
-      carbonOffset.totalRetired = carbonOffset.totalRetired.plus(toDecimal(event.params.value, 18))
-      CarbonMetricUtils.updateCarbonTokenRetirements(new TCO2(), event.block.timestamp, event.params.value)
-    }
-  }
-
   carbonOffset.currentSupply = toDecimal(offsetERC20.totalSupply(), 18)
   carbonOffset.lastUpdate = transaction.timestamp
+
+  carbonOffset.save()
+}
+
+export function handleRetired(event: Retired): void {
+  let transaction = loadOrCreateTransaction(event.transaction, event.block)
+  let offsetERC20 = ToucanCarbonOffsets.bind(event.address)
+
+  let carbonOffset = loadOrCreateCarbonOffset(transaction, event.address, 'Toucan', 'Verra')
+
+  if (carbonOffset.methodology != 'AM0001') {
+    let retire = loadOrCreateRetire(carbonOffset, transaction)
+    retire.value = toDecimal(event.params.tokenId, 18)
+    retire.retiree = event.params.sender.toHexString()
+
+    retire.save()
+
+    carbonOffset.totalRetired = carbonOffset.totalRetired.plus(retire.value)
+    CarbonMetricUtils.updateCarbonTokenRetirements(new TCO2(), event.block.timestamp, event.params.tokenId)
+  }
 
   carbonOffset.save()
 }

--- a/polygon-bridged-carbon/src/utils/CarbonMetrics.ts
+++ b/polygon-bridged-carbon/src/utils/CarbonMetrics.ts
@@ -79,7 +79,15 @@ export class CarbonMetricUtils {
     carbonMetrics.mco2Supply = BigDecimal.zero()
     carbonMetrics.uboSupply = BigDecimal.zero()
     carbonMetrics.nboSupply = BigDecimal.zero()
+    carbonMetrics.bctRedeemed = BigDecimal.zero()
+    carbonMetrics.nctRedeemed = BigDecimal.zero()
+    carbonMetrics.uboRedeemed = BigDecimal.zero()
+    carbonMetrics.nboRedeemed = BigDecimal.zero()
     carbonMetrics.totalCarbonSupply = BigDecimal.zero()
+
+    carbonMetrics.bctCrosschainSupply = BigDecimal.zero()
+    carbonMetrics.nctCrosschainSupply = BigDecimal.zero()
+    carbonMetrics.totalCrosschainSupply = BigDecimal.zero()
 
     carbonMetrics.tco2Retired = BigDecimal.zero()
     carbonMetrics.mco2Retired = BigDecimal.zero()

--- a/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
+++ b/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
@@ -28,11 +28,14 @@ export function loadOrCreateCarbonOffset(
       carbonOffset.totalBridged = BigDecimal.fromString('0')
       carbonOffset.totalRetired = BigDecimal.fromString('0')
       carbonOffset.currentSupply = BigDecimal.fromString('0')
+      carbonOffset.name = 'MCO2'
       carbonOffset.vintage = ''
       carbonOffset.vintageYear = ''
       carbonOffset.projectID = ''
       carbonOffset.standard = ''
       carbonOffset.methodology = ''
+      carbonOffset.methodologyCategory = ''
+      carbonOffset.country = ''
       carbonOffset.region = ''
       carbonOffset.storageMethod = ''
       carbonOffset.method = ''
@@ -43,6 +46,10 @@ export function loadOrCreateCarbonOffset(
       carbonOffset.correspAdjustment = ''
       carbonOffset.additionalCertification = ''
       carbonOffset.klimaRanking = BigInt.fromString('0')
+      carbonOffset.balanceBCT = BigDecimal.fromString('0')
+      carbonOffset.balanceNCT = BigDecimal.fromString('0')
+      carbonOffset.balanceUBO = BigDecimal.fromString('0')
+      carbonOffset.balanceNBO = BigDecimal.fromString('0')
       carbonOffset.lastUpdate = transaction.timestamp
     }
   }
@@ -92,6 +99,10 @@ export function createToucanCarbonOffset(
   carbonOffset.klimaRanking = BigInt.fromString(
     carbonOffset.vintage + carbonOffset.projectID.substring(4).padStart(6, '0')
   )
+  carbonOffset.balanceBCT = BigDecimal.fromString('0')
+  carbonOffset.balanceNCT = BigDecimal.fromString('0')
+  carbonOffset.balanceUBO = BigDecimal.fromString('0')
+  carbonOffset.balanceNBO = BigDecimal.fromString('0')
   carbonOffset.lastUpdate = transaction.timestamp
 
   // Manually update some of the items missing from the initial Toucan bridging
@@ -158,6 +169,10 @@ export function createC3ProjectToken(transaction: Transaction, token: Address, b
   carbonOffset.klimaRanking = BigInt.fromString(
     carbonOffset.vintage + carbonOffset.projectID.substring(4).padStart(6, '0')
   )
+  carbonOffset.balanceBCT = BigDecimal.fromString('0')
+  carbonOffset.balanceNCT = BigDecimal.fromString('0')
+  carbonOffset.balanceUBO = BigDecimal.fromString('0')
+  carbonOffset.balanceNBO = BigDecimal.fromString('0')
   carbonOffset.lastUpdate = transaction.timestamp
 
   return carbonOffset as CarbonOffset

--- a/polygon-bridged-carbon/subgraph.yaml
+++ b/polygon-bridged-carbon/subgraph.yaml
@@ -329,6 +329,8 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+        - event: Retired(address,uint256)
+          handler: handleRetired
       file: ./src/ToucanCarbonOffsets.ts
   - name: C3ProjectToken
     kind: ethereum/contract


### PR DESCRIPTION
- Remove assumption that TCO2s sent to the zero address are always retired
- Fix missing entity values on creation

This is merged to staging and the indexed deployment can be found here: https://api.thegraph.com/subgraphs/name/cujowolf/polygon-bridged-carbon-dev

These changes have also been incorporated into the staging deployment of the carbon dashboard for additional verificaiton.