### PR TITLE
Add additional retirement event signature to TCO2s

### DIFF
--- a/lib/abis/ToucanCarbonOffsets_1.4.0.json
+++ b/lib/abis/ToucanCarbonOffsets_1.4.0.json
@@ -1,5 +1,10 @@
 [
   {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -30,20 +35,51 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "sender",
+        "name": "bridger",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "tokenId",
+        "name": "fees",
         "type": "uint256"
       }
     ],
-    "name": "Retired",
+    "name": "FeeBurnt",
     "type": "event"
   },
-
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "bridger",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fees",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeePaid",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
   {
     "anonymous": false,
     "inputs": [
@@ -162,6 +198,60 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "bridgeBurn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "bridgeMint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burnFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "contractRegistry",
     "outputs": [
@@ -208,6 +298,19 @@
         "type": "bool"
       }
     ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "defractionalize",
+    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -264,7 +367,7 @@
           },
           {
             "internalType": "address",
-            "name": "controller",
+            "name": "beneficiary",
             "type": "address"
           }
         ],
@@ -437,9 +540,24 @@
   {
     "inputs": [
       {
+        "internalType": "string",
+        "name": "retiringEntityString",
+        "type": "string"
+      },
+      {
         "internalType": "address",
-        "name": "to",
+        "name": "beneficiary",
         "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "beneficiaryString",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "retirementMessage",
+        "type": "string"
       },
       {
         "internalType": "uint256",
@@ -447,7 +565,7 @@
         "type": "uint256"
       }
     ],
-    "name": "mintBadgeNFT",
+    "name": "mintCertificateLegacy",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -540,6 +658,45 @@
       }
     ],
     "name": "retire",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "retirementEventId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "retiringEntityString",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "beneficiaryString",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "retirementMessage",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "retireAndMintCertificate",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -558,7 +715,13 @@
       }
     ],
     "name": "retireFrom",
-    "outputs": [],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "retirementEventId",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -658,6 +821,19 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
     "type": "function"
   }
 ]

--- a/polygon-bridged-carbon/subgraph.yaml
+++ b/polygon-bridged-carbon/subgraph.yaml
@@ -331,6 +331,8 @@ templates:
           handler: handleTransfer
         - event: Retired(address,uint256)
           handler: handleRetired
+        - event: Retired(address,uint256,uint256)
+          handler: handleRetired_1_4_0
       file: ./src/ToucanCarbonOffsets.ts
   - name: C3ProjectToken
     kind: ethereum/contract


### PR DESCRIPTION
Version 1.4.0 of the TCO2 contract introduced a new `Retired` event signature.

This adds both the full abi for version 1.4.0 of the TCO2 implementation, as well as adding the new signature to a combined abi for use in a common subgraph template.

Fully indexed staged deployment can be found here: https://api.thegraph.com/subgraphs/id/QmPw7ch26mmSQSncbaBq6NAu8btraFGkmmfMddb8NqLHQE

Using this query against the current deployment, you can see that the correct `totalRetired` is now populated with 12.5 rather than zero.

```
query MyQuery {
  carbonOffsets(where: {projectID: "VCS-1764"}) {
    id
    vintageYear
    totalRetired
    totalBridged
  }
}
```