### PR TITLE
Switch to updated GitHub Actions logic for storing output

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,9 +64,9 @@ jobs:
 
           if [[ "${{ matrix.value }}" =~ .*"bridged-carbon".* ]]
           then
-              echo "::set-output name=subgraph::${PREFIX}${{ matrix.value }}"
+              echo "subgraph=${PREFIX}${{ matrix.value }}" >> $GITHUB_OUTPUT
           else
-              echo "::set-output name=subgraph::${PREFIX}klimadao-${{ matrix.value }}"
+              echo "subgraph=${PREFIX}klimadao-${{ matrix.value }}" >> $GITHUB_OUTPUT
           fi
         env:
           REF: ${{ github.ref }}


### PR DESCRIPTION
Resolves warning about `set-output` being deprecated using new logic defined in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/