### PR TITLE
Digital Carbon - Prevent duplicate methodology categories

### DIFF
--- a/polygon-digital-carbon/src/utils/MethodologyCategories.ts
+++ b/polygon-digital-carbon/src/utils/MethodologyCategories.ts
@@ -30,6 +30,10 @@ export class MethodologyCategories {
         continue
       }
       if (categories.length > 0) {
+        let category = '' + map.get(currentMethodology)
+        if (categories.includes(category)) {
+          continue
+        }
         categories += ', '
       }
       categories += map.get(currentMethodology)


### PR DESCRIPTION
In the case where there are multiple methodologies for a carbon credit, only record a unique category list rather than the category for each methodology.