### PR TITLE
Digtal Carbon - Vintage Calculation

### DIFF
--- a/lib/utils/Dates.ts
+++ b/lib/utils/Dates.ts
@@ -24,3 +24,8 @@ export function stdYearFromTimestamp(timestamp: BigInt): i32 {
   let date = new Date(<i64>timestamp.toI32() * 1000)
   return date.getUTCFullYear()
 }
+
+export function stdYearFromTimestampNew(timestamp: BigInt): i32 {
+  let date = new Date(timestamp.toI64() * 1000)
+  return date.getUTCFullYear()
+}

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -1,5 +1,5 @@
 import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
-import { stdYearFromTimestamp } from '../../../lib/utils/Dates'
+import { stdYearFromTimestampNew as stdYearFromTimestamp } from '../../../lib/utils/Dates'
 import { ZERO_BI } from '../../../lib/utils/Decimals'
 import { C3ProjectToken } from '../../generated/templates/C3ProjectToken/C3ProjectToken'
 import { CarbonCredit } from '../../generated/schema'

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -3,6 +3,11 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
+features:
+  - grafting
+graft:
+  base: QmXdpavWty4qRoTEF1LzmXDAsmSYFNPCVjgY1kSrQx1CA4
+  block: 42035327
 dataSources:
   - kind: ethereum/contract
     name: ToucanFactory


### PR DESCRIPTION
Originally the integer used to represent the vintage of a credit was converted to an i32. This caused and overflow and incorrect reporting of vintages issues past 2038.