### PR TITLE
Digital Carbon - Retirement ID update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
-bonds/node_modules/
-protocol-metrics/node_modules/
+**/node_modules/
 jspm_packages/
 
 # TypeScript v1 declaration files
@@ -70,22 +68,10 @@ typings/
 .next
 
 # thegraph build
-build
-bonds/build
-pairs/build
-polygon-digital-carbon/build
-protocol-metrics/build
-user-carbon/build
-vesting/build
+**/build/
 
 # thegraph generated
-generated/
-bonds/generated
-pairs/generated
-polygon-digital-carbon/generated
-protocol-metrics/generated
-user-carbon/generated
-vesting/generated
+**/generated/
 
 # env files
 .env.local

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -328,6 +328,9 @@ type Retire @entity {
   "Block timestamp of retirement"
   timestamp: BigInt!
 
+  "Final provenance record created by this retirement"
+  provenance: ProvenanceRecord
+
   ### Additional attributes if applicable ###
 
   klimaRetire: KlimaRetire @derivedFrom(field: "retire")

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -19,11 +19,11 @@ export function handleMossRetired(event: MossRetired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -23,7 +23,7 @@ export function handleMossRetired(event: MossRetired): void {
   loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -50,11 +50,11 @@ export function handleToucanRetired(event: ToucanRetired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -81,10 +81,11 @@ export function handleC3Retired(event: C3Retired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.retiringAddress)
+  loadOrCreateAccount(event.params.beneficiaryAddress)
 
-  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -111,10 +112,11 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.retiringAddress)
+  loadOrCreateAccount(event.params.beneficiaryAddress)
 
-  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -141,10 +143,11 @@ export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): voi
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.retiringAddress)
+  loadOrCreateAccount(event.params.beneficiaryAddress)
 
-  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -19,11 +19,11 @@ export function handleMossRetired(event: MossRetired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -34,7 +34,13 @@ export function handleMossRetired(event: MossRetired): void {
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
 
-  saveKlimaRetire(event.transaction.from, retire.id, index, event.params.retiredAmount.div(BigInt.fromI32(100)), false)
+  saveKlimaRetire(
+    event.params.beneficiaryAddress,
+    retire.id,
+    index,
+    event.params.retiredAmount.div(BigInt.fromI32(100)),
+    false
+  )
 }
 
 export function handleToucanRetired(event: ToucanRetired): void {
@@ -44,11 +50,11 @@ export function handleToucanRetired(event: ToucanRetired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -59,7 +65,13 @@ export function handleToucanRetired(event: ToucanRetired): void {
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
 
-  saveKlimaRetire(event.transaction.from, retire.id, index, event.params.retiredAmount.div(BigInt.fromI32(100)), false)
+  saveKlimaRetire(
+    event.params.beneficiaryAddress,
+    retire.id,
+    index,
+    event.params.retiredAmount.div(BigInt.fromI32(100)),
+    false
+  )
 }
 
 export function handleC3Retired(event: C3Retired): void {
@@ -69,11 +81,10 @@ export function handleC3Retired(event: C3Retired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.transaction.from)
-  loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -84,7 +95,13 @@ export function handleC3Retired(event: C3Retired): void {
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
 
-  saveKlimaRetire(event.transaction.from, retire.id, index, event.params.retiredAmount.div(BigInt.fromI32(100)), false)
+  saveKlimaRetire(
+    event.params.beneficiaryAddress,
+    retire.id,
+    index,
+    event.params.retiredAmount.div(BigInt.fromI32(100)),
+    false
+  )
 }
 
 export function handleCarbonRetired(event: CarbonRetired): void {
@@ -94,11 +111,10 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.transaction.from)
-  loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -109,7 +125,13 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
 
-  saveKlimaRetire(event.transaction.from, retire.id, index, event.params.retiredAmount.div(BigInt.fromI32(100)), false)
+  saveKlimaRetire(
+    event.params.beneficiaryAddress,
+    retire.id,
+    index,
+    event.params.retiredAmount.div(BigInt.fromI32(100)),
+    false
+  )
 }
 
 export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): void {
@@ -119,11 +141,10 @@ export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): voi
   let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
-  let sender = loadOrCreateAccount(event.transaction.from)
-  loadOrCreateAccount(event.params.beneficiaryAddress)
+  let sender = loadOrCreateAccount(event.params.beneficiaryAddress)
   loadOrCreateAccount(event.params.retiringAddress)
 
-  let retire = loadRetire(event.transaction.from.concatI32(sender.totalRetirements - 1))
+  let retire = loadRetire(event.params.beneficiaryAddress.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -134,5 +155,11 @@ export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): voi
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
 
-  saveKlimaRetire(event.transaction.from, retire.id, index, event.params.retiredAmount.div(BigInt.fromI32(100)), false)
+  saveKlimaRetire(
+    event.params.beneficiaryAddress,
+    retire.id,
+    index,
+    event.params.retiredAmount.div(BigInt.fromI32(100)),
+    false
+  )
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -22,11 +22,11 @@ export function saveToucanRetirement(event: Retired): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.params.sender)
-  let sender = loadOrCreateAccount(event.transaction.from)
+  loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.sender)
 
   saveRetire(
-    event.transaction.from.concatI32(sender.totalRetirements),
+    event.params.sender.concatI32(sender.totalRetirements),
     credit.id,
     ZERO_ADDRESS,
     'OTHER',
@@ -39,18 +39,7 @@ export function saveToucanRetirement(event: Retired): void {
     event.transaction.hash
   )
 
-  incrementAccountRetirements(event.transaction.from)
-
-  recordProvenance(
-    event.transaction.hash,
-    event.address,
-    null,
-    event.transaction.to === KLIMA_INFINITY_DIAMOND ? KLIMA_INFINITY_DIAMOND : event.params.sender,
-    ZERO_ADDRESS,
-    'RETIREMENT',
-    event.params.tokenId,
-    event.block.timestamp
-  )
+  incrementAccountRetirements(event.params.sender)
 }
 
 export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
@@ -65,11 +54,11 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.params.sender)
-  let sender = loadOrCreateAccount(event.transaction.from)
+  loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.sender)
 
   saveRetire(
-    event.transaction.from.concatI32(sender.totalRetirements),
+    event.params.sender.concatI32(sender.totalRetirements),
     credit.id,
     ZERO_ADDRESS,
     'OTHER',
@@ -83,18 +72,7 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
     event.params.eventId.toString()
   )
 
-  incrementAccountRetirements(event.transaction.from)
-
-  recordProvenance(
-    event.transaction.hash,
-    event.address,
-    null,
-    event.transaction.to === KLIMA_INFINITY_DIAMOND ? KLIMA_INFINITY_DIAMOND : event.params.sender,
-    ZERO_ADDRESS,
-    'RETIREMENT',
-    event.params.amount,
-    event.block.timestamp
-  )
+  incrementAccountRetirements(event.params.sender)
 }
 
 export function handleVCUOMinted(event: VCUOMinted): void {
@@ -113,11 +91,11 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.params.sender)
-  let sender = loadOrCreateAccount(event.transaction.from)
+  loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.sender)
 
   saveRetire(
-    event.transaction.from.concatI32(sender.totalRetirements),
+    event.params.sender.concatI32(sender.totalRetirements),
     projectAddress,
     ZERO_ADDRESS,
     'OTHER',
@@ -141,7 +119,7 @@ export function handleVCUOMinted(event: VCUOMinted): void {
     event.block.timestamp
   )
 
-  incrementAccountRetirements(event.transaction.from)
+  incrementAccountRetirements(event.params.sender)
 }
 
 export function handleMossRetirement(event: CarbonOffset): void {
@@ -164,11 +142,11 @@ export function handleMossRetirement(event: CarbonOffset): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.params.sender)
-  let sender = loadOrCreateAccount(event.transaction.from)
+  loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.sender)
 
   saveRetire(
-    event.transaction.from.concatI32(sender.totalRetirements),
+    event.params.sender.concatI32(sender.totalRetirements),
     MCO2_ERC20_CONTRACT,
     MCO2_ERC20_CONTRACT,
     'OTHER',
@@ -181,7 +159,7 @@ export function handleMossRetirement(event: CarbonOffset): void {
     event.transaction.hash
   )
 
-  incrementAccountRetirements(event.transaction.from)
+  incrementAccountRetirements(event.params.sender)
 }
 
 export function saveICRRetirement(event: RetiredVintage): void {
@@ -191,11 +169,11 @@ export function saveICRRetirement(event: RetiredVintage): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.params.account)
-  let sender = loadOrCreateAccount(event.transaction.from)
+  loadOrCreateAccount(event.transaction.from)
+  let sender = loadOrCreateAccount(event.params.account)
 
   saveRetire(
-    event.transaction.from.concatI32(sender.totalRetirements),
+    event.params.account.concatI32(sender.totalRetirements),
     credit.id,
     ZERO_ADDRESS,
     'OTHER',
@@ -210,7 +188,7 @@ export function saveICRRetirement(event: RetiredVintage): void {
     event.params.data.toString()
   )
 
-  incrementAccountRetirements(event.transaction.from)
+  incrementAccountRetirements(event.params.account)
 
   recordProvenance(
     event.transaction.hash,

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -1,3 +1,4 @@
+import { Address } from '@graphprotocol/graph-ts'
 import { KLIMA_INFINITY_DIAMOND, MCO2_ERC20_CONTRACT, ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { ZERO_BI } from '../../lib/utils/Decimals'
 import { C3OffsetNFT, VCUOMinted } from '../generated/C3-Offset/C3OffsetNFT'
@@ -22,24 +23,25 @@ export function saveToucanRetirement(event: Retired): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.transaction.from)
-  let sender = loadOrCreateAccount(event.params.sender)
+  let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
+  loadOrCreateAccount(event.params.sender) // Beneficiary address
 
   saveRetire(
-    event.params.sender.concatI32(sender.totalRetirements),
+    sender.id.concatI32(sender.totalRetirements),
     credit.id,
     ZERO_ADDRESS,
     'OTHER',
     event.params.tokenId,
     event.params.sender,
     '',
-    event.transaction.from,
+    senderAddress,
     '',
     event.block.timestamp,
     event.transaction.hash
   )
 
-  incrementAccountRetirements(event.params.sender)
+  incrementAccountRetirements(senderAddress)
 
   updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 }
@@ -56,25 +58,26 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.transaction.from)
-  let sender = loadOrCreateAccount(event.params.sender)
+  let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
+  loadOrCreateAccount(event.params.sender) // Beneficiary address
 
   saveRetire(
-    event.params.sender.concatI32(sender.totalRetirements),
+    sender.id.concatI32(sender.totalRetirements),
     credit.id,
     ZERO_ADDRESS,
     'OTHER',
     event.params.amount,
     event.params.sender,
     '',
-    event.transaction.from,
+    senderAddress,
     '',
     event.block.timestamp,
     event.transaction.hash,
     event.params.eventId.toString()
   )
 
-  incrementAccountRetirements(event.params.sender)
+  incrementAccountRetirements(senderAddress)
 
   updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 }
@@ -95,26 +98,27 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.transaction.from)
-  let sender = loadOrCreateAccount(event.params.sender)
+  loadOrCreateAccount(event.params.sender)
+  let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
 
   saveRetire(
-    event.params.sender.concatI32(sender.totalRetirements),
+    sender.id.concatI32(sender.totalRetirements),
     projectAddress,
     ZERO_ADDRESS,
     'OTHER',
     retireAmount,
     event.params.sender,
     '',
-    event.transaction.from,
+    senderAddress,
     '',
     event.block.timestamp,
     event.transaction.hash
   )
 
-  updateProvenanceForRetirement(event.transaction.hash, projectAddress, null)
+  updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 
-  incrementAccountRetirements(event.params.sender)
+  incrementAccountRetirements(senderAddress)
 }
 
 export function handleMossRetirement(event: CarbonOffset): void {
@@ -139,22 +143,23 @@ export function handleMossRetirement(event: CarbonOffset): void {
   // Ensure account entities are created for all addresses
   loadOrCreateAccount(event.params.sender)
   let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
 
   saveRetire(
-    event.transaction.from.concatI32(sender.totalRetirements),
+    sender.id.concatI32(sender.totalRetirements),
     MCO2_ERC20_CONTRACT,
     MCO2_ERC20_CONTRACT,
     'OTHER',
     event.params.carbonTon,
     event.params.sender,
     event.params.onBehalfOf,
-    event.transaction.from,
+    senderAddress,
     '',
     event.block.timestamp,
     event.transaction.hash
   )
 
-  incrementAccountRetirements(event.transaction.from)
+  incrementAccountRetirements(senderAddress)
 }
 
 export function saveICRRetirement(event: RetiredVintage): void {
@@ -164,18 +169,19 @@ export function saveICRRetirement(event: RetiredVintage): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.transaction.from)
-  let sender = loadOrCreateAccount(event.params.account)
+  loadOrCreateAccount(event.params.account)
+  let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
 
   saveRetire(
-    event.params.account.concatI32(sender.totalRetirements),
+    sender.id.concatI32(sender.totalRetirements),
     credit.id,
     ZERO_ADDRESS,
     'OTHER',
     event.params.amount,
     event.params.account,
     '',
-    event.transaction.from,
+    senderAddress,
     '',
     event.block.timestamp,
     event.transaction.hash,
@@ -183,7 +189,7 @@ export function saveICRRetirement(event: RetiredVintage): void {
     event.params.data.toString()
   )
 
-  incrementAccountRetirements(event.params.account)
+  incrementAccountRetirements(senderAddress)
 
   updateProvenanceForRetirement(event.transaction.hash, event.address, event.params.tokenId)
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -42,8 +42,6 @@ export function saveToucanRetirement(event: Retired): void {
   )
 
   incrementAccountRetirements(senderAddress)
-
-  updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 }
 
 export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
@@ -78,8 +76,6 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
   )
 
   incrementAccountRetirements(senderAddress)
-
-  updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 }
 
 export function handleVCUOMinted(event: VCUOMinted): void {
@@ -115,8 +111,6 @@ export function handleVCUOMinted(event: VCUOMinted): void {
     event.block.timestamp,
     event.transaction.hash
   )
-
-  updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 
   incrementAccountRetirements(senderAddress)
 }
@@ -190,6 +184,4 @@ export function saveICRRetirement(event: RetiredVintage): void {
   )
 
   incrementAccountRetirements(senderAddress)
-
-  updateProvenanceForRetirement(event.transaction.hash, event.address, event.params.tokenId)
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -7,7 +7,7 @@ import { Retired, Retired1 as Retired_1_4_0 } from '../generated/templates/Touca
 import { incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
 import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit'
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
-import { recordProvenance } from './utils/Provenance'
+import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
 import { saveRetire } from './utils/Retire'
 
 export function saveToucanRetirement(event: Retired): void {
@@ -40,6 +40,8 @@ export function saveToucanRetirement(event: Retired): void {
   )
 
   incrementAccountRetirements(event.params.sender)
+
+  updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 }
 
 export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
@@ -73,6 +75,8 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
   )
 
   incrementAccountRetirements(event.params.sender)
+
+  updateProvenanceForRetirement(event.transaction.hash, event.address, null)
 }
 
 export function handleVCUOMinted(event: VCUOMinted): void {
@@ -108,16 +112,7 @@ export function handleVCUOMinted(event: VCUOMinted): void {
     event.transaction.hash
   )
 
-  recordProvenance(
-    event.transaction.hash,
-    projectAddress,
-    null,
-    event.transaction.to === KLIMA_INFINITY_DIAMOND ? KLIMA_INFINITY_DIAMOND : event.params.sender,
-    ZERO_ADDRESS,
-    'RETIREMENT',
-    retireAmount,
-    event.block.timestamp
-  )
+  updateProvenanceForRetirement(event.transaction.hash, projectAddress, null)
 
   incrementAccountRetirements(event.params.sender)
 }
@@ -190,14 +185,5 @@ export function saveICRRetirement(event: RetiredVintage): void {
 
   incrementAccountRetirements(event.params.account)
 
-  recordProvenance(
-    event.transaction.hash,
-    event.address,
-    event.params.tokenId,
-    event.transaction.to === KLIMA_INFINITY_DIAMOND ? KLIMA_INFINITY_DIAMOND : event.params.account,
-    ZERO_ADDRESS,
-    'RETIREMENT',
-    event.params.amount,
-    event.block.timestamp
-  )
+  updateProvenanceForRetirement(event.transaction.hash, event.address, event.params.tokenId)
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -137,11 +137,11 @@ export function handleMossRetirement(event: CarbonOffset): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.transaction.from)
-  let sender = loadOrCreateAccount(event.params.sender)
+  loadOrCreateAccount(event.params.sender)
+  let sender = loadOrCreateAccount(event.transaction.from)
 
   saveRetire(
-    event.params.sender.concatI32(sender.totalRetirements),
+    event.transaction.from.concatI32(sender.totalRetirements),
     MCO2_ERC20_CONTRACT,
     MCO2_ERC20_CONTRACT,
     'OTHER',
@@ -154,7 +154,7 @@ export function handleMossRetirement(event: CarbonOffset): void {
     event.transaction.hash
   )
 
-  incrementAccountRetirements(event.params.sender)
+  incrementAccountRetirements(event.transaction.from)
 }
 
 export function saveICRRetirement(event: RetiredVintage): void {

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -142,20 +142,6 @@ function recordTransfer(
   if (tokenId !== null) {
     tokenVar = tokenId.toString()
   }
-  log.debug(
-    'tokenAddress: {}, tokenId: {}, from: {}, to: {}, amount: {}, hash: {}, logIndex: {}, timestamp: {}, blockNumber: {}',
-    [
-      tokenAddress.toHexString(),
-      tokenVar,
-      from.toHexString(),
-      to.toHexString(),
-      amount.toString(),
-      hash.toHexString(),
-      logIndex.toString(),
-      timestamp.toString(),
-      blockNumber.toString(),
-    ]
-  )
   // Ignore transfers of zero value
   if (amount == ZERO_BI) return
 
@@ -212,6 +198,7 @@ function recordTransfer(
     toHolding.lastUpdated = timestamp
     toHolding.save()
 
+    // Exclude MCO2 retirements that are bridged back for one final burn to the zero address on mainnet
     if (from != ZERO_ADDRESS && tokenAddress != MCO2_ERC20_CONTRACT) {
       recordProvenance(hash, tokenAddress, tokenId, from, to, 'TRANSFER', amount, timestamp)
 

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -201,6 +201,10 @@ function recordTransfer(
 
   if (to == ZERO_ADDRESS) {
     credit.currentSupply = credit.currentSupply.minus(amount)
+
+    recordProvenance(hash, tokenAddress, tokenId, from, to, 'TRANSFER', amount, timestamp)
+
+    credit.provenanceCount += 1
   } else {
     loadOrCreateAccount(to)
     let toHolding = loadOrCreateHolding(to, tokenAddress, tokenId)

--- a/polygon-digital-carbon/src/utils/Provenance.ts
+++ b/polygon-digital-carbon/src/utils/Provenance.ts
@@ -111,17 +111,15 @@ export function recordProvenance(
   senderHolding.save()
 }
 
-export function updateProvenanceForRetirement(hash: Bytes, tokenAddress: Address, tokenId: BigInt | null): void {
-  let creditId =
-    tokenId !== null
-      ? Bytes.fromHexString(tokenAddress.toHexString()).concatI32(tokenId.toI32())
-      : Bytes.fromHexString(tokenAddress.toHexString())
-
+export function updateProvenanceForRetirement(creditId: Bytes): Bytes | null {
   let credit = loadCarbonCredit(creditId)
   let id = creditId.concat(ZERO_ADDRESS).concatI32(credit.provenanceCount - 1)
   let record = ProvenanceRecord.load(id)
-  if (record != null) {
-    record.transactionType = 'RETIREMENT'
-    record.save()
+  if (record == null) {
+    return null
   }
+
+  record.transactionType = 'RETIREMENT'
+  record.save()
+  return record.id
 }

--- a/polygon-digital-carbon/src/utils/Provenance.ts
+++ b/polygon-digital-carbon/src/utils/Provenance.ts
@@ -4,6 +4,7 @@ import { loadCarbonCredit } from './CarbonCredit'
 import { loadOrCreateHolding } from './Holding'
 import { ZERO_BI } from '../../../lib/utils/Decimals'
 import { loadOrCreateToucanBatch } from './ToucanBatch'
+import { ZERO_ADDRESS } from '../../../lib/utils/Constants'
 
 export function recordProvenance(
   hash: Bytes,
@@ -108,4 +109,19 @@ export function recordProvenance(
 
   senderHolding.activeProvenanceRecords = senderActiveRecords
   senderHolding.save()
+}
+
+export function updateProvenanceForRetirement(hash: Bytes, tokenAddress: Address, tokenId: BigInt | null): void {
+  let creditId =
+    tokenId !== null
+      ? Bytes.fromHexString(tokenAddress.toHexString()).concatI32(tokenId.toI32())
+      : Bytes.fromHexString(tokenAddress.toHexString())
+
+  let credit = loadCarbonCredit(creditId)
+  let id = creditId.concat(ZERO_ADDRESS).concatI32(credit.provenanceCount - 1)
+  let record = ProvenanceRecord.load(id)
+  if (record != null) {
+    record.transactionType = 'RETIREMENT'
+    record.save()
+  }
 }

--- a/polygon-digital-carbon/src/utils/Retire.ts
+++ b/polygon-digital-carbon/src/utils/Retire.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { Retire } from '../../generated/schema'
+import { updateProvenanceForRetirement } from './Provenance'
 
 export function saveRetire(
   id: Bytes,
@@ -28,6 +29,7 @@ export function saveRetire(
   retire.retiringName = retiringName
   retire.timestamp = timestamp
   retire.hash = hash
+  retire.provenance = updateProvenanceForRetirement(credit)
   if (bridgeID !== null) retire.bridgeID = bridgeID
   retire.save()
 }

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -3,11 +3,6 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
-features:
-  - grafting
-graft:
-  base: QmXdpavWty4qRoTEF1LzmXDAsmSYFNPCVjgY1kSrQx1CA4
-  block: 42035327
 dataSources:
   - kind: ethereum/contract
     name: ToucanFactory


### PR DESCRIPTION
Ensure consistency between all retirement IDs being created to use the `tx.from` address. Additionally use all transfer events to create any needed provenance records, then flag the latest as a retirement if a retirement happened in the same transaction hash.

Small generalization for gitignore.