### PR TITLE
Carbonmark: Add tokenId to Listing Entity

### DIFF
--- a/carbonmark/schema.graphql
+++ b/carbonmark/schema.graphql
@@ -47,6 +47,7 @@ type Listing @entity {
   totalAmountToSell: BigInt!
   leftToSell: BigInt!
   tokenAddress: Bytes!
+  tokenId: BigInt!
   active: Boolean
   deleted: Boolean # uint256
   batches: [BigInt!] # uint256

--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -24,6 +24,7 @@ export function handleListingCreated(event: ListingCreated): void {
   listing.totalAmountToSell = event.params.amount
   listing.leftToSell = event.params.amount
   listing.tokenAddress = event.params.token
+  listing.tokenId = event.params.tokenId
   listing.active = true
   listing.deleted = false
   listing.singleUnitPrice = event.params.price

--- a/carbonmark/src/Entities.ts
+++ b/carbonmark/src/Entities.ts
@@ -55,6 +55,7 @@ export function loadOrCreateListing(id: string): Listing {
     listing.totalAmountToSell = ZERO_BI
     listing.leftToSell = ZERO_BI
     listing.tokenAddress = ZERO_ADDRESS
+    listing.tokenId = ZERO_BI
     listing.active = false
     listing.deleted = false
     listing.batches = [ZERO_BI]


### PR DESCRIPTION
With ICR listings include the tokenId of the `Listing` entity for querying the details of a listing.