### PR TITLE
tokenstandard + symbol

### DIFF
--- a/carbonmark/schema.graphql
+++ b/carbonmark/schema.graphql
@@ -42,6 +42,11 @@ type Category @entity {
   id: String!
 }
 
+enum TokenStandard {
+  ERC20
+  ERC1155
+}
+
 type Listing @entity {
   id: ID!
   totalAmountToSell: BigInt!
@@ -62,6 +67,7 @@ type Listing @entity {
   activities: [Activity!] @derivedFrom(field: "listing")
   createdAt: BigInt
   updatedAt: BigInt
+  tokenStandard: TokenStandard!
 }
 
 type Activity @entity {

--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -21,6 +21,15 @@ export function handleListingCreated(event: ListingCreated): void {
   let tokenContract = ERC20.bind(event.params.token)
   let tokenSymbol = tokenContract.try_symbol()
 
+  // If the token is not an ERC20, it is an ERC1155
+  if (!tokenSymbol.reverted) {
+    listing.tokenStandard = 'ERC20'
+    listing.tokenSymbol = tokenSymbol.value
+  } else {
+    listing.tokenStandard = 'ERC1155'
+    listing.tokenSymbol = project.id
+  }
+
   listing.totalAmountToSell = event.params.amount
   listing.leftToSell = event.params.amount
   listing.tokenAddress = event.params.token
@@ -34,9 +43,6 @@ export function handleListingCreated(event: ListingCreated): void {
   listing.seller = event.params.account
   listing.createdAt = event.block.timestamp
   listing.updatedAt = event.block.timestamp
-  if (!tokenSymbol.reverted) {
-    listing.tokenSymbol = tokenSymbol.value
-  }
 
   listing.save()
 

--- a/carbonmark/src/Entities.ts
+++ b/carbonmark/src/Entities.ts
@@ -68,6 +68,7 @@ export function loadOrCreateListing(id: string): Listing {
     listing.createdAt = ZERO_BI
     listing.updatedAt = ZERO_BI
     listing.tokenSymbol = ''
+    listing.tokenStandard = ''
     listing.save()
   }
   return listing

--- a/carbonmark/subgraph.yaml
+++ b/carbonmark/subgraph.yaml
@@ -23,6 +23,8 @@ dataSources:
           file: ../lib/abis/Carbonmark.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
+        - name: ERC1155
+          file: ../lib/abis/ERC1155.json
       eventHandlers:
         - event: ListingCreated(bytes32,address,address,uint256,uint256,uint256,uint256,uint256)
           handler: handleListingCreated


### PR DESCRIPTION
Added a tokenStandard field for a more reliable way to check the token type (in case future non-ICR 1155s have zero index tokenIds).

Also added a token symbol for 1155s in `registry-registryId-vintage` format.