### PR TITLE
Update minFill amount in `handleListingUpdated`

### DIFF
--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -70,6 +70,9 @@ export function handleListingUpdated(event: ListingUpdated): void {
   let listing = loadOrCreateListing(event.params.id.toHexString())
   let activity = loadOrCreateActivity(event.transaction.hash.toHexString().concat('ListingUpdated'))
 
+    // always ensure the minFillAmount is updated
+    listing.minFillAmount = event.params.newMinFillAmount
+
   if (event.params.oldAmount != event.params.newAmount) {
     listing.totalAmountToSell = event.params.newAmount
     listing.leftToSell = event.params.newAmount


### PR DESCRIPTION
The frontend was getting a contract error as the min fill had been updated and a retire attempt below current minFill but above the original was reverting.