### PR TITLE
Adjust Historical Activity Amounts to Reflect ICR migration

### DIFF
--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -67,7 +67,7 @@ export function handleListingCreated(event: ListingCreated): void {
 }
 
 export function handleListingUpdated(event: ListingUpdated): void {
-  let blockNumber = event.block.number  
+  let blockNumber = event.block.number
   // User should already exist from creating the listing.
 
   let listing = loadOrCreateListing(event.params.id.toHexString())
@@ -77,6 +77,9 @@ export function handleListingUpdated(event: ListingUpdated): void {
 
   // always ensure the minFillAmount is updated
   listing.minFillAmount = event.params.newMinFillAmount
+
+  // only handling historical activity amounts for ICR migration
+  activity.amount = handleMigrationDecimals(project.registry, blockNumber, event.params.newAmount)
 
   if (event.params.oldAmount != event.params.newAmount) {
     listing.totalAmountToSell = event.params.newAmount

--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -5,14 +5,16 @@ import {
   loadOrCreateProject,
   loadOrCreatePurchase,
   loadOrCreateUser,
+  loadProject,
 } from './Entities'
-import { ZERO_BI } from '../../lib/utils/Decimals'
+import { ZERO_BI, handleMigrationDecimals } from '../../lib/utils/Decimals'
 import { ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { ERC20 } from '../generated/Carbonmark/ERC20'
 import { ERC1155 } from '../generated/Carbonmark/ERC1155'
 import { Bytes, log } from '@graphprotocol/graph-ts'
 
 export function handleListingCreated(event: ListingCreated): void {
+  let blockNumber = event.block.number
   // Ensure the user entity exists
   loadOrCreateUser(event.params.account)
   loadOrCreateUser(event.transaction.from)
@@ -53,7 +55,7 @@ export function handleListingCreated(event: ListingCreated): void {
   listing.save()
 
   let activity = loadOrCreateActivity(event.transaction.hash.toHexString().concat('ListingCreated'))
-  activity.amount = event.params.amount
+  activity.amount = handleMigrationDecimals(project.registry, blockNumber, event.params.amount)
   activity.price = event.params.price
   activity.timeStamp = event.block.timestamp
   activity.activityType = 'CreatedListing'
@@ -65,13 +67,16 @@ export function handleListingCreated(event: ListingCreated): void {
 }
 
 export function handleListingUpdated(event: ListingUpdated): void {
+  let blockNumber = event.block.number  
   // User should already exist from creating the listing.
 
   let listing = loadOrCreateListing(event.params.id.toHexString())
   let activity = loadOrCreateActivity(event.transaction.hash.toHexString().concat('ListingUpdated'))
 
-    // always ensure the minFillAmount is updated
-    listing.minFillAmount = event.params.newMinFillAmount
+  let project = loadProject(listing.project)
+
+  // always ensure the minFillAmount is updated
+  listing.minFillAmount = event.params.newMinFillAmount
 
   if (event.params.oldAmount != event.params.newAmount) {
     listing.totalAmountToSell = event.params.newAmount
@@ -82,7 +87,7 @@ export function handleListingUpdated(event: ListingUpdated): void {
     activity.activityType = 'UpdatedQuantity'
     activity.project = listing.project
     activity.user = event.transaction.from
-    activity.previousAmount = event.params.oldAmount
+    activity.previousAmount = handleMigrationDecimals(project.registry, blockNumber, event.params.oldAmount)
     activity.amount = event.params.newAmount
     activity.timeStamp = event.block.timestamp
     activity.seller = listing.seller
@@ -136,6 +141,7 @@ export function handleListingUpdated(event: ListingUpdated): void {
 }
 
 export function handleListingFilled(event: ListingFilled): void {
+  let blockNumber = event.block.number
   // Ensure the buyer user entity exists
   loadOrCreateUser(event.transaction.from)
 
@@ -143,14 +149,16 @@ export function handleListingFilled(event: ListingFilled): void {
   let buyerActivty = loadOrCreateActivity(event.transaction.hash.toHexString().concat('Purchase'))
   let sellerActivity = loadOrCreateActivity(event.transaction.hash.toHexString().concat('Sold'))
 
-  listing.leftToSell = listing.leftToSell.minus(event.params.amount)
+  let amount = handleMigrationDecimals(loadProject(listing.project).registry, blockNumber, event.params.amount)
+
+  listing.leftToSell = listing.leftToSell.minus(amount)
   if (listing.leftToSell == ZERO_BI) {
     listing.active = false
   }
   listing.updatedAt = event.block.timestamp
   listing.save()
 
-  buyerActivty.amount = event.params.amount
+  buyerActivty.amount = amount
   buyerActivty.price = listing.singleUnitPrice
   buyerActivty.timeStamp = event.block.timestamp
   buyerActivty.activityType = 'Purchase'
@@ -161,7 +169,7 @@ export function handleListingFilled(event: ListingFilled): void {
   buyerActivty.buyer = event.transaction.from
   buyerActivty.save()
 
-  sellerActivity.amount = event.params.amount
+  sellerActivity.amount = amount
   sellerActivity.price = listing.singleUnitPrice
   sellerActivity.timeStamp = event.block.timestamp
   sellerActivity.activityType = 'Sold'
@@ -174,7 +182,7 @@ export function handleListingFilled(event: ListingFilled): void {
 
   let purchase = loadOrCreatePurchase(event.transaction.hash)
   purchase.price = listing.singleUnitPrice
-  purchase.amount = event.params.amount
+  purchase.amount = amount
   purchase.timeStamp = event.block.timestamp
   purchase.user = event.transaction.from
   purchase.listing = listing.id

--- a/carbonmark/src/Entities.ts
+++ b/carbonmark/src/Entities.ts
@@ -101,6 +101,14 @@ export function loadOrCreatePurchase(id: Bytes): Purchase {
   return purchase
 }
 
+export function loadProject(projectId: string): Project {
+  let project = Project.load(projectId)
+  if (project == null) {
+    throw new Error('Project does not exist')
+  }
+  return project
+}
+
 function createCountry(id: string): void {
   let country = Country.load(id)
   if (country == null) {

--- a/lib/utils/Constants.ts
+++ b/lib/utils/Constants.ts
@@ -110,6 +110,8 @@ export const NFT_CO2COMPOUND_INIT_TIMESTAMP = BigInt.fromString('1638486000') //
 
 export const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
 
+export const ICR_MIGRATION_BLOCK = 55190341;
+
 // Klima Infinity Addresses
 export const KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0xac298cd34559b9acfaedea8344a977eceff1c0fd')
 export const KLIMA_INFINITY_DIAMOND = Address.fromString('0x8cE54d9625371fb2a068986d32C85De8E6e995f8')

--- a/lib/utils/Decimals.ts
+++ b/lib/utils/Decimals.ts
@@ -1,4 +1,5 @@
-import { BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+import { BigDecimal, BigInt, log } from '@graphprotocol/graph-ts'
+import { ICR_MIGRATION_BLOCK } from './Constants'
 
 export const DEFAULT_DECIMALS = 18
 
@@ -29,4 +30,20 @@ export function toDecimal(value: BigInt, decimals: number = DEFAULT_DECIMALS): B
     .toBigDecimal()
 
   return value.divDecimal(precision)
+}
+
+export function toWei(value: BigInt): BigInt {
+  let weiDecimals: BigInt = BigInt.fromI32(10).pow(DEFAULT_DECIMALS as u8)
+  return value.times(weiDecimals)
+}
+
+export function handleMigrationDecimals(registry: string, blockNumber: BigInt, amount: BigInt): BigInt {
+  log.info('qwe1: {} qwe2: {} qwe3: {}', [blockNumber.toString(), BigInt.fromI32(ICR_MIGRATION_BLOCK).toString(), registry])
+
+  if (registry == 'ICR' && blockNumber.lt(BigInt.fromI32(ICR_MIGRATION_BLOCK))) {
+    log.info('qwe4: {}', [toWei(amount).toString()])
+    return toWei(amount)
+  } else {
+    return amount
+  }
 }


### PR DESCRIPTION
Historical amounts, all for inactive listings, are handled conditionally prior to a block after the ICR migration and before any further listings.

current deployment: https://thegraph.com/hosted-service/subgraph/psparacino/carbonmark--testing-only