### PR TITLE
Carbonmark and PDC manifest network templates

### DIFF
--- a/carbonmark/networkConfig/matic.json
+++ b/carbonmark/networkConfig/matic.json
@@ -1,0 +1,7 @@
+{
+    "network": "matic",
+    "Carbonmark": {
+      "address": "0x7B51dBc2A8fD98Fe0924416E628D5755f57eB821",
+      "startBlock": "49503672"
+    }
+}

--- a/carbonmark/networkConfig/mumbai.json
+++ b/carbonmark/networkConfig/mumbai.json
@@ -1,0 +1,7 @@
+{
+  "network": "mumbai",
+  "Carbonmark": {
+    "address": "0xD973F90a4C49607EABeFdb2C45d4F39436c7e7fA",
+    "startBlock": "42480600"
+  }
+}

--- a/carbonmark/package.json
+++ b/carbonmark/package.json
@@ -7,6 +7,8 @@
     "updateICR": "ts-node src/scripts/updateICRProjects.ts",
     "codegen": "rm -rf ./generated && graph codegen",
     "build": "graph build",
+    "prepare-matic": "npx mustache networkConfig/matic.json subgraph.template.yaml > subgraph.yaml",
+    "prepare-mumbai": "npx mustache networkConfig/mumbai.json subgraph.template.yaml > subgraph.yaml",
     "create-local": "graph create --node http://127.0.0.1:8020 carbonmark",
     "remove-local": "graph remove --node http://127.0.0.1:8020 carbonmark",
     "watch-local": "graph deploy --watch --debug --node http://127.0.0.1:8020/ --ipfs http://127.0.0.1:5001 carbonmark",

--- a/carbonmark/subgraph.template.yaml
+++ b/carbonmark/subgraph.template.yaml
@@ -1,0 +1,36 @@
+specVersion: 0.0.4
+description: Carbonmark
+repository: https://github.com/KlimaDAO/klima-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: Carbonmark
+    network: {{network}}
+    source:
+      address: '{{Carbonmark.address}}'
+      abi: Carbonmark
+      startBlock: {{Carbonmark.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/Carbonmark.ts
+      entities:
+        - Carbonmark
+      abis:
+        - name: Carbonmark
+          file: ../lib/abis/Carbonmark.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+        - name: ERC1155
+          file: ../lib/abis/ERC1155.json
+      eventHandlers:
+        - event: ListingCreated(bytes32,address,address,uint256,uint256,uint256,uint256,uint256)
+          handler: handleListingCreated
+        - event: ListingUpdated(bytes32,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)
+          handler: handleListingUpdated
+        - event: ListingFilled(bytes32,address,uint256,uint256)
+          handler: handleListingFilled
+        - event: ListingCancelled(bytes32)
+          handler: handleListingCancelled

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "@graphprotocol/graph-ts": "0.31.0",
     "prettier": "2.7.1",
     "ts-node": "^10.9.2"
+  },
+  "dependencies": {
+    "mustache": "4.2.0"
   }
 }

--- a/polygon-digital-carbon/networkConfig/matic.json
+++ b/polygon-digital-carbon/networkConfig/matic.json
@@ -1,0 +1,75 @@
+{
+  "network": "matic",
+  "ToucanCarbonOffsetsFactory": {
+    "address": "0x2359677E513Bc83106268514c5B2De3C29C849ea",
+    "startBlock": "20078328"
+  },
+  "ToucanCarbonOffsetBatch": {
+    "address": "0x8A4d7458dDe3023A3B24225D62087701A88b09DD",
+    "startBlock": "20078307"
+  },
+  "BCT": {
+    "address": "0x2F800Db0fdb5223b3C3f354886d907A671414A7F",
+    "startBlock": "20078351"
+  },
+  "NCT": {
+    "address": "0xD838290e877E0188a4A44700463419ED96c16107",
+    "startBlock": "24705011"
+  },
+  "ToucanCrossChainMessenger": {
+    "address": "0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf",
+    "startBlock": "31390596"
+  },
+  "ToucanRegenBridge": {
+    "address": "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC",
+    "startBlock": "40568139"
+  },
+  "MossCarbon": {
+    "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
+    "startBlock": "23193932"
+  },
+  "MossCarbonOffset": {
+    "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
+    "startBlock": "25259584"
+  },
+  "C3ProjectTokenFactory": {
+    "address": "0xa4c951B30952f5E2feFC8a92F4d3c7551925A63B",
+    "startBlock": "25427652"
+  },
+  "UBO": {
+    "address": "0x2B3eCb0991AF0498ECE9135bcD04013d7993110c",
+    "startBlock": "25429110"
+  },
+  "NBO": {
+    "address": "0x6BCa3B77C1909Ce1a4Ba1A20d1103bDe8d222E48",
+    "startBlock": "25428966"
+  },
+  "C3-Offset": {
+    "address": "0x7b364DFc0e085468aFDe869DF20036D80b8868e7",
+    "startBlock": "27049043"
+  },
+  "ICRCarbonContractRegistry": {
+    "address": "0x9f87988ff45e9b58ae30fa1685088460125a7d8a",
+    "startBlock": "42035327"
+  },
+  "RetireToucanCarbon": {
+    "address": "0xCefb61aF5325C0c100cBd77eb4c9F51d17B189Ca",
+    "startBlock": "25476120"
+  },
+  "RetireMossCarbon": {
+    "address": "0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5",
+    "startBlock": "25476110"
+  },
+  "RetireC3Carbon": {
+    "address": "0x933AF8c652c696FB0969Eb85DDd111edb2b4E057",
+    "startBlock": "27175005"
+  },
+  "KlimaInfinity": {
+    "address": "0x8cE54d9625371fb2a068986d32C85De8E6e995f8",
+    "startBlock": "36550000"
+  },
+  "sKlimaERC20V1": {
+    "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
+    "startBlock": "20190686"
+  }
+}

--- a/polygon-digital-carbon/networkConfig/mumbai.json
+++ b/polygon-digital-carbon/networkConfig/mumbai.json
@@ -1,0 +1,76 @@
+{
+    "network": "mumbai",
+    "ToucanCarbonOffsetsFactory": {
+      "address": "0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8",
+      "startBlock": "47284985"
+    },
+    "ToucanCarbonOffsetBatch": {
+      "address": "0x8A4d7458dDe3023A3B24225D62087701A88b09DD",
+      "startBlock": "47284985"
+    },
+    "BCT": {
+      "address": "0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5",
+      "startBlock": "47284985"
+    },
+    "NCT": {
+      "address": "0xD838290e877E0188a4A44700463419ED96c16107",
+      "startBlock": "47284985"
+    },
+    "ToucanCrossChainMessenger": {
+      "address": "0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf",
+      "startBlock": "47284985"
+    },
+    "ToucanRegenBridge": {
+      "address": "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC",
+      "startBlock": "47284985"
+    },
+    "MossCarbon": {
+      "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
+      "startBlock": "23193932"
+    },
+    "MossCarbonOffset": {
+      "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
+      "startBlock": "47284985"
+    },
+    "C3ProjectTokenFactory": {
+      "address": "0x3bc4ff4787c0f7cd83efb424176f559a00cf28c3",
+      "startBlock": "47284985"
+    },
+    "UBO": {
+      "address": "0x1c08ed3ff245de937a6414c2c39e372f2640f5f8",
+      "startBlock": "47284985"
+    },
+    "NBO": {
+      "address": "0x28d5158d45ec651133fac4c858bed65252ed5b7b",
+      "startBlock": "47284985"
+    },
+    "C3-Offset": {
+      "address": "0xddafb3df0e464cd3252d50da405909185a7e1fbf",
+      "startBlock": "47284985"
+    },
+    "ICRCarbonContractRegistry": {
+      "address": "0x825cccb05d82fcd0381e523116a03b9301e91c61",
+      "startBlock": "47284985"
+    },
+    "RetireToucanCarbon": {
+      "address": "0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca",
+      "startBlock": "47284985"
+    },
+    "RetireMossCarbon": {
+      "address": "0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5",
+      "startBlock": "47284985"
+    },
+    "RetireC3Carbon": {
+      "address": "0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff",
+      "startBlock": "47284985"
+    },
+    "KlimaInfinity": {
+      "address": "0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8",
+      "startBlock": "47284985"
+    },
+    "sKlimaERC20V1": {
+      "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
+      "startBlock": "20190686"
+    }
+  }
+  

--- a/polygon-digital-carbon/package.json
+++ b/polygon-digital-carbon/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "codegen": "rm -rf ./generated && graph codegen",
     "build": "graph build",
+    "prepare-matic": "npx mustache networkConfig/matic.json subgraph.template.yaml > subgraph.yaml",
+    "prepare-mumbai": "npx mustache networkConfig/mumbai.json subgraph.template.yaml > subgraph.yaml",
     "create-local": "graph create --node http://127.0.0.1:8020 polygon-carbon",
     "remove-local": "graph remove --node http://127.0.0.1:8020 polygon-carbon",
     "watch-local": "graph deploy --watch --debug --node http://127.0.0.1:8020/ --ipfs http://127.0.0.1:5001 polygon-carbon",

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -1,0 +1,520 @@
+specVersion: 0.0.4
+description: Polygon Carbon
+repository: https://github.com/KlimaDAO/klima-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: ToucanFactory
+    network: {{network}}
+    source:
+      address: '{{ToucanCarbonOffsetsFactory.address}}'
+      abi: ToucanCarbonOffsetsFactory
+      startBlock: {{ToucanCarbonOffsetsFactory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/templates/ToucanFactory.ts
+      entities:
+        - ToucanCarbonOffsetsFactory
+      abis:
+        - name: ToucanCarbonOffsetsFactory
+          file: ../lib/abis/ToucanCarbonOffsetsFactory.json
+        - name: ToucanCarbonOffsets
+          file: ../lib/abis/ToucanCarbonOffsets.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: TokenCreated(uint256,address)
+          handler: handleNewTCO2
+  - kind: ethereum/contract
+    name: ToucanCarbonOffsetBatch
+    network: {{network}}
+    source:
+      address: '{{ToucanCarbonOffsetBatch.address}}'
+      abi: ToucanCarbonOffsetBatches
+      startBlock: {{ToucanCarbonOffsetBatch.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ToucanCarbonOffsetBatchHandler.ts
+      entities:
+        - ToucanCarbonOffsetBatch
+      abis:
+        - name: ToucanCarbonOffsetBatches
+          file: ../lib/abis/ToucanCarbonOffsetBatches.json
+      eventHandlers:
+        - event: BatchMinted(address,uint256)
+          handler: handleBatchMinted
+        - event: BatchUpdated(uint256,string,uint256)
+          handler: handleBatchUpdated
+        - event: Transfer(indexed address,indexed address,indexed uint256)
+          handler: handleBatchTransfer
+  - kind: ethereum/contract
+    name: BCT
+    network: {{network}}
+    source:
+      address: '{{BCT.address}}'
+      abi: ToucanCarbonPool
+      startBlock: {{BCT.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ToucanCarbonPoolHandler.ts
+      entities:
+        - BCT
+      abis:
+        - name: ToucanCarbonPool
+          file: ../lib/abis/ToucanCarbonPool.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Deposited(address,uint256)
+          handler: handleDeposited
+        - event: Redeemed(address,address,uint256)
+          handler: handleRedeemed
+        - event: TCO2Bridged(indexed uint32,indexed address,uint256)
+          handler: handleToucanTCO2Bridged
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+  - kind: ethereum/contract
+    name: NCT
+    network: {{network}}
+    source:
+      address: '{{NCT.address}}'
+      abi: ToucanCarbonPool
+      startBlock: {{NCT.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ToucanCarbonPoolHandler.ts
+      entities:
+        - NCT
+      abis:
+        - name: ToucanCarbonPool
+          file: ../lib/abis/ToucanCarbonPool.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Deposited(address,uint256)
+          handler: handleDeposited
+        - event: Redeemed(address,address,uint256)
+          handler: handleRedeemed
+        - event: TCO2Bridged(indexed uint32,indexed address,uint256)
+          handler: handleToucanTCO2Bridged
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+  # Toucan cross chain bridges
+  - kind: ethereum/contract
+    name: ToucanCrossChainMessenger
+    network: {{network}}
+    source:
+      address: '{{ToucanCrossChainMessenger.address}}'
+      abi: ToucanCrossChainMessenger
+      startBlock: {{ToucanCrossChainMessenger.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ToucanCrossChainMessengerHandler.ts
+      entities:
+        - ToucanCrossChainMessenger
+      abis:
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+        - name: ToucanCrossChainMessenger
+          file: ../lib/abis/ToucanCrosschainMessenger_Combined.json
+      eventHandlers:
+        # v1.0.0
+        - event: BridgeRequestReceived(indexed uint32,uint32,indexed address,indexed address,uint256,bytes32)
+          handler: handleBridgeRequestReceived_1_0_0
+        - event: BridgeRequestSent(uint32,indexed uint32,indexed address,indexed address,uint256,uint256,bytes32)
+          handler: handleBridgeRequestSent_1_0_0
+        # v1.1.0
+        - event: BridgeRequestReceived(indexed uint32,uint32,indexed address,address,indexed address,uint256,bytes32)
+          handler: handleBridgeRequestReceived_1_1_0
+        - event: BridgeRequestSent(uint32,indexed uint32,indexed address,address,indexed address,uint256,uint256,bytes32)
+          handler: handleBridgeRequestSent_1_1_0
+  - kind: ethereum/contract
+    name: ToucanRegenBridge
+    network: {{network}}
+    source:
+      address: '{{ToucanRegenBridge.address}}'
+      abi: ToucanRegenBridge
+      startBlock: {{ToucanRegenBridge.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ToucanCrossChainMessengerHandler.ts
+      entities:
+        - ToucanCrossChainMessenger
+      abis:
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+        - name: ToucanRegenBridge
+          file: ../lib/abis/ToucanRegenBridge.json
+      eventHandlers:
+        - event: Bridge(address,string,address,uint256)
+          handler: handleToucanRegenBridge
+        - event: Issue(string,address,address,uint256,string)
+          handler: handleToucanRegenIssue
+  - kind: ethereum/contract
+    name: MossCarbon
+    network: {{network}}
+    source:
+      address: '{{MossCarbon.address}}'
+      abi: ERC20
+      startBlock: {{MossCarbon.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/TransferHandler.ts
+      entities:
+        - MossCarbon
+      abis:
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleCreditTransfer
+  - kind: ethereum/contract
+    name: MossCarbonOffset
+    network: {{network}}
+    source:
+      address: '{{MossCarbonOffset.address}}'
+      abi: CarbonChain
+      startBlock: {{MossCarbonOffset.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/RetirementHandler.ts
+      entities:
+        - MossCarbonOffset
+      abis:
+        - name: CarbonChain
+          file: ../lib/abis/MossOffsetCarbon.json
+      eventHandlers:
+        - event: CarbonOffset(uint256,string,string,address,bytes32,indexed uint256,indexed uint256)
+          handler: handleMossRetirement
+        # - event: CarbonOffsetBatch((uint256,bytes32,uint256,uint256),uint256,bytes32,uint256)
+        #   handler: handleMossRetirementToMainnet
+  - kind: ethereum/contract
+    name: C3ProjectTokenFactory
+    network: {{network}}
+    source:
+      address: '{{C3ProjectTokenFactory.address}}'
+      abi: C3ProjectTokenFactory
+      startBlock: {{C3ProjectTokenFactory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/templates/C3ProjectTokenFactory.ts
+      entities:
+        - C3ProjectTokenFactory
+      abis:
+        - name: C3ProjectTokenFactory
+          file: ../lib/abis/C3ProjectTokenFactory.json
+        - name: C3ProjectToken
+          file: ../lib/abis/C3ProjectToken.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: NewTokenProject(string,address)
+          handler: handleNewC3T
+  - kind: ethereum/contract
+    name: UBO
+    network: {{network}}
+    source:
+      address: '{{UBO.address}}'
+      abi: C3CarbonPool
+      startBlock: {{UBO.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/C3CarbonPoolHandler.ts
+      entities:
+        - UBO
+      abis:
+        - name: C3CarbonPool
+          file: ../lib/abis/C3CarbonPool.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Deposited(address,uint256)
+          handler: handleDeposited
+        - event: Redeemed(address,address,uint256)
+          handler: handleRedeemed
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+  - kind: ethereum/contract
+    name: NBO
+    network: {{network}}
+    source:
+      address: '{{NBO.address}}'
+      abi: C3CarbonPool
+      startBlock: {{NBO.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/C3CarbonPoolHandler.ts
+      entities:
+        - NBO
+      abis:
+        - name: C3CarbonPool
+          file: ../lib/abis/C3CarbonPool.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Deposited(address,uint256)
+          handler: handleDeposited
+        - event: Redeemed(address,address,uint256)
+          handler: handleRedeemed
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+  - kind: ethereum/contract
+    name: C3-Offset
+    network: {{network}}
+    source:
+      address: '{{C3-Offset.address}}'
+      abi: C3OffsetNFT
+      startBlock: {{C3-Offset.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/RetirementHandler.ts
+      entities:
+        - C3-VCUO
+      abis:
+        - name: C3OffsetNFT
+          file: ../lib/abis/C3OffsetNFT.json
+      eventHandlers:
+        - event: VCUOMinted(address,uint256)
+          handler: handleVCUOMinted
+  - kind: ethereum/contract
+    name: ICRCarbonContractRegistry
+    network: {{network}}
+    source:
+      address: '{{ICRCarbonContractRegistry.address}}'
+      abi: ICRCarbonContractRegistry
+      startBlock: {{ICRCarbonContractRegistry.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/templates/ICRCarbonContractRegistry.ts
+      entities:
+        - ICRCarbonContractRegistry
+      abis:
+        - name: ICRCarbonContractRegistry
+          file: ../lib/abis/ICRCarbonContractRegistry.json
+        - name: ICRProjectToken
+          file: ../lib/abis/ICRProjectToken.json
+        - name: ERC1155
+          file: ../lib/abis/ERC1155.json
+      eventHandlers:
+        - event: ProjectCreated(indexed uint256,indexed address,string)
+          handler: handleNewICC
+  # Retirement aggregator
+  - kind: ethereum/contract
+    name: RetireToucanCarbon
+    network: {{network}}
+    source:
+      address: '{{RetireToucanCarbon.address}}'
+      abi: RetireToucanCarbon
+      startBlock: {{RetireToucanCarbon.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/KlimaAggregator.ts
+      entities:
+        - KlimaRetire
+      abis:
+        - name: RetireToucanCarbon
+          file: ../lib/abis/RetireToucanCarbon.json
+        - name: KlimaCarbonRetirements
+          file: ../lib/abis/KlimaCarbonRetirements.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: ToucanRetired(indexed address,indexed address,string,string,indexed address,address,uint256)
+          handler: handleToucanRetired
+  - kind: ethereum/contract
+    name: RetireMossCarbon
+    network: {{network}}
+    source:
+      address: '{{RetireMossCarbon.address}}'
+      abi: RetireMossCarbon
+      startBlock: {{RetireMossCarbon.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/KlimaAggregator.ts
+      entities:
+        - KlimaRetire
+      abis:
+        - name: RetireMossCarbon
+          file: ../lib/abis/RetireMossCarbon.json
+        - name: KlimaCarbonRetirements
+          file: ../lib/abis/KlimaCarbonRetirements.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: MossRetired(indexed address,indexed address,string,string,indexed address,uint256)
+          handler: handleMossRetired
+  - kind: ethereum/contract
+    name: RetireC3Carbon
+    network: {{network}}
+    source:
+      address: '{{RetireC3Carbon.address}}'
+      abi: RetireC3Carbon
+      startBlock: {{RetireC3Carbon.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/KlimaAggregator.ts
+      entities:
+        - KlimaRetire
+      abis:
+        - name: RetireC3Carbon
+          file: ../lib/abis/RetireC3Carbon.json
+        - name: KlimaCarbonRetirements
+          file: ../lib/abis/KlimaCarbonRetirements.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: C3Retired(indexed address,indexed address,string,string,indexed address,address,uint256)
+          handler: handleC3Retired
+  - kind: ethereum/contract
+    name: KlimaInfinity
+    network: {{network}}
+    source:
+      address: '{{KlimaInfinity.address}}'
+      abi: KlimaInfinity
+      startBlock: {{KlimaInfinity.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/KlimaAggregator.ts
+      entities:
+        - KlimaRetire
+      abis:
+        - name: KlimaInfinity
+          file: ../lib/abis/KlimaInfinity.json
+        - name: KlimaCarbonRetirements
+          file: ../lib/abis/KlimaCarbonRetirements.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: CarbonRetired(uint8,indexed address,string,indexed address,string,string,indexed address,address,uint256)
+          handler: handleCarbonRetired
+        - event: CarbonRetired(uint8,indexed address,string,indexed address,string,string,indexed address,address,uint256,uint256)
+          handler: handleCarbonRetiredWithTokenId
+  # Track KLIMA rebases for creating supply snapshot
+  - kind: ethereum/contract
+    name: sKlimaERC20V1
+    network: {{network}}
+    source:
+      address: '{{sKlimaERC20V1.address}}'
+      abi: sKlimaERC20V1
+      startBlock: {{sKlimaERC20V1.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - sKlima
+      abis:
+        - name: sKlimaERC20V1
+          file: ../lib/abis/sKlimaERC20V1.json
+      eventHandlers:
+        - event: LogRebase(indexed uint256,uint256,uint256)
+          handler: handleRebase
+      file: ./src/sKlimaV1.ts
+templates:
+  - name: ToucanCarbonOffsets
+    kind: ethereum/contract
+    network: {{network}}
+    source:
+      abi: ToucanCarbonOffsets
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - ToucanCarbonOffsets
+      abis:
+        - name: ToucanCarbonOffsets
+          file: ../lib/abis/ToucanCarbonOffsets.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Retired(address,uint256)
+          handler: handleToucanRetired
+        - event: Retired(address,uint256,uint256)
+          handler: handleToucanRetired_1_4_0
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleCreditTransfer
+      file: ./src/TransferHandler.ts
+  - name: C3ProjectToken
+    kind: ethereum/contract
+    network: {{network}}
+    source:
+      abi: C3ProjectToken
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - C3ProjectToken
+      abis:
+        - name: C3ProjectToken
+          file: ../lib/abis/C3ProjectToken.json
+        - name: ERC20
+          file: ../lib/abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleCreditTransfer
+      file: ./src/TransferHandler.ts
+  - name: ICRProjectToken
+    kind: ethereum/contract
+    network: {{network}}
+    source:
+      abi: ICRProjectToken
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - ICRProjectToken
+      abis:
+        - name: ICRProjectToken
+          file: ../lib/abis/ICRProjectToken.json
+        - name: ERC1155
+          file: ../lib/abis/ERC1155.json
+      eventHandlers:
+        - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handle1155CreditTransfer
+        - event: TransferBatch(indexed address,indexed address,indexed address,uint256[],uint256[])
+          handler: handle1155CreditTransferBatch
+        - event: RetiredVintage(indexed address,indexed uint256,uint256,uint256,bytes)
+          handler: handleICRRetired
+        - event: ExPostCreated(indexed uint256,uint256,uint256,uint256,string)
+          handler: handleExPostCreated
+        - event: ExAnteMinted(indexed uint256,indexed uint256,indexed address,uint256)
+          handler: handleExAnteMinted
+      file: ./src/TransferHandler.ts

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -3,11 +3,6 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
-features:
-  - grafting
-graft:
-  base: QmZsuZJAUe9wJL9zy1D1D5qRrfruhB28Z64Rc4934Zkx4h
-  block: 42035327
 dataSources:
   - kind: ethereum/contract
     name: ToucanFactory

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,6 +4104,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mustache@npm:4.2.0":
+  version: 4.2.0
+  resolution: "mustache@npm:4.2.0"
+  bin:
+    mustache: bin/mustache
+  checksum: 928fcb63e3aa44a562bfe9b59ba202cccbe40a46da50be6f0dd831b495be1dd7e38ca4657f0ecab2c1a89dc7bccba0885eab7ee7c1b215830da765758c7e0506
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.0.2, nanoid@npm:^3.1.20, nanoid@npm:^3.1.23":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
@@ -4856,6 +4865,7 @@ __metadata:
   dependencies:
     "@graphprotocol/graph-cli": 0.56.0
     "@graphprotocol/graph-ts": 0.31.0
+    mustache: 4.2.0
     prettier: 2.7.1
     ts-node: ^10.9.2
   languageName: unknown


### PR DESCRIPTION
Templating for pdc and carbonmark polygon and mumbai. This will make it quick to add amoy as well when mumbai is deprecated.

Couldn't find addresses for most of the Toucan mumbai contracts, but not sure that's a a high priority issue. The block numbers for mumbai are also geared towards testing the jcredit subgraph and so are probably not accurate for general purpose testing.