### PR TITLE
`polygon-digital-carbon` : Add isExAnte field to `Token` entity

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -88,6 +88,9 @@ type Token @entity {
   "Token Id"
   tokenId: BigInt
 
+  "isExAnte Identifier"
+  isExAnte: Boolean
+
   "Latest price in USD"
   latestPriceUSD: BigDecimal
 

--- a/polygon-digital-carbon/src/utils/Token.ts
+++ b/polygon-digital-carbon/src/utils/Token.ts
@@ -61,6 +61,7 @@ export function createICRTokenWithCall(tokenAddress: Address, tokenId: BigInt): 
     token.symbol = symbol
     token.decimals = 18
     token.tokenId = tokenId
+    token.isExAnte = !isExPost
 
     token.save()
   }

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -3,11 +3,6 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
-features:
-  - grafting
-graft:
-  base: QmaKAu5JTHgjGobXF9yZxZmtuQ1YTZUKUkwM3kswtcrwC3
-  block: 57571000
 dataSources:
   - kind: ethereum/contract
     name: ToucanFactory


### PR DESCRIPTION
With this change we should be able to remove the ICR subgraph dependency in the api.