### PR TITLE
Draft/c3 wip

### DIFF
--- a/carbonmark/subgraph.yaml
+++ b/carbonmark/subgraph.yaml
@@ -6,9 +6,9 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: Carbonmark
-    network: matic
+    network: mumbai
     source:
-      address: '0x7B51dBc2A8fD98Fe0924416E628D5755f57eB821'
+      address: '0xD973F90a4C49607EABeFdb2C45d4F39436c7e7fA'
       abi: Carbonmark
       startBlock: 49503672
     mapping:

--- a/carbonmark/subgraph.yaml
+++ b/carbonmark/subgraph.yaml
@@ -6,9 +6,9 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: Carbonmark
-    network: mumbai
+    network: matic
     source:
-      address: '0xD973F90a4C49607EABeFdb2C45d4F39436c7e7fA'
+      address: '0x7B51dBc2A8fD98Fe0924416E628D5755f57eB821'
       abi: Carbonmark
       startBlock: 49503672
     mapping:

--- a/lib/abis/C3ProjectToken.json
+++ b/lib/abis/C3ProjectToken.json
@@ -1,5 +1,185 @@
 [
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAsyncData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "transferee",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "reason",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "currentIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "live",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "status",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "info",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct AsyncData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAsyncRetirementCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getIdentifier",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProjectIdentifier",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProjectInfo",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "project_id",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "project_type",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "registry",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "country",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "region",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "methodology",
+            "type": "string"
+          },
+          {
+            "internalType": "uint64",
+            "name": "period_start",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "period_end",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          },
+          {
+            "internalType": "string",
+            "name": "uri",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "ac",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct ProjectData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/lib/abis/C3ProjectToken.json
+++ b/lib/abis/C3ProjectToken.json
@@ -1,279 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      }
-    ],
-    "name": "getAsyncData",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "account",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "beneficiary",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256"
-          },
-          {
-            "internalType": "string",
-            "name": "transferee",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "reason",
-            "type": "string"
-          },
-          {
-            "internalType": "uint256",
-            "name": "currentIndex",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "live",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "status",
-            "type": "uint256"
-          },
-          {
-            "internalType": "string",
-            "name": "info",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct AsyncData",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getAsyncRetirementCount",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getIdentifier",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getProjectIdentifier",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getProjectInfo",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "string",
-            "name": "name",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "project_id",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "project_type",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "registry",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "country",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "region",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "methodology",
-            "type": "string"
-          },
-          {
-            "internalType": "uint64",
-            "name": "period_start",
-            "type": "uint64"
-          },
-          {
-            "internalType": "uint64",
-            "name": "period_end",
-            "type": "uint64"
-          },
-          {
-            "internalType": "bool",
-            "name": "active",
-            "type": "bool"
-          },
-          {
-            "internalType": "string",
-            "name": "uri",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "ac",
-            "type": "string"
-          }
-        ],
-        "internalType": "struct ProjectData",
-        "name": "",
-        "type": "tuple"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "name": "beneficiary",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "name": "_transferee",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "name": "_reason",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "name": "live",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "name": "index",
-        "type": "uint256"
-      }
-    ],
-    "name": "StartAsyncToken",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "name": "beneficiary",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "name": "_transferee",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "name": "_reason",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "name": "live",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "name": "success",
-        "type": "bool"
-      },
-      {
-        "indexed": false,
-        "name": "index",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "name": "nftIndex",
-        "type": "uint256"
-      }
-    ],
-    "name": "EndAsyncToken",
-    "type": "event"
-  },
-  {
     "anonymous": false,
     "inputs": [
       {
@@ -419,6 +145,65 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "asyncDataList",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "transferee",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "currentIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "live",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "status",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "info",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "account",
         "type": "address"
@@ -470,6 +255,103 @@
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "status",
+        "type": "uint256"
+      }
+    ],
+    "name": "finalizeAsync",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAsyncData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "account",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "transferee",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "reason",
+            "type": "string"
+          },
+          {
+            "internalType": "uint256",
+            "name": "currentIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "live",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "status",
+            "type": "uint256"
+          },
+          {
+            "internalType": "string",
+            "name": "info",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct AsyncData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAsyncRetirementCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -699,9 +581,47 @@
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "transferee",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
       }
     ],
     "name": "offset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "transferee",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "offsetFor",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/lib/abis/C3ProjectToken.json
+++ b/lib/abis/C3ProjectToken.json
@@ -1,633 +1,727 @@
 [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Approval",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "previousOwner",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "OwnershipTransferred",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "Paused",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
-        }
-      ],
-      "name": "Transfer",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "Unpaused",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "owner",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        }
-      ],
-      "name": "allowance",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "approve",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "account",
-          "type": "address"
-        }
-      ],
-      "name": "balanceOf",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "decimals",
-      "outputs": [
-        {
-          "internalType": "uint8",
-          "name": "",
-          "type": "uint8"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "subtractedValue",
-          "type": "uint256"
-        }
-      ],
-      "name": "decreaseAllowance",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getIdentifier",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getProjectIdentifier",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getProjectInfo",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "string",
-              "name": "name",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "project_id",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "project_type",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "registry",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "country",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "region",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "methodology",
-              "type": "string"
-            },
-            {
-              "internalType": "uint64",
-              "name": "period_start",
-              "type": "uint64"
-            },
-            {
-              "internalType": "uint64",
-              "name": "period_end",
-              "type": "uint64"
-            },
-            {
-              "internalType": "bool",
-              "name": "active",
-              "type": "bool"
-            },
-            {
-              "internalType": "string",
-              "name": "uri",
-              "type": "string"
-            },
-            {
-              "internalType": "string",
-              "name": "ac",
-              "type": "string"
-            }
-          ],
-          "internalType": "struct ProjectData",
-          "name": "",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "getVintage",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "identifier",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "spender",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "addedValue",
-          "type": "uint256"
-        }
-      ],
-      "name": "increaseAllowance",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_name",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "_prefix",
-          "type": "string"
-        },
-        {
-          "internalType": "string",
-          "name": "_identifier",
-          "type": "string"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_vintage",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "_projectKey",
-          "type": "string"
-        },
-        {
-          "internalType": "address",
-          "name": "_orchestratorAddress",
-          "type": "address"
-        }
-      ],
-      "name": "initialize",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "name",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "nftFromId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "offset",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "tokenId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "name": "onERC721Received",
-      "outputs": [
-        {
-          "internalType": "bytes4",
-          "name": "",
-          "type": "bytes4"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "orchestratorAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "owner",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "paused",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "projectKey",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "renounceOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "symbol",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "totalSupply",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "recipient",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "transfer",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "sender",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "recipient",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "transferFrom",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "newOwner",
-          "type": "address"
-        }
-      ],
-      "name": "transferOwnership",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "vintage",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "_transferee",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "_reason",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "live",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "StartAsyncToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "beneficiary",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "_transferee",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "_reason",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "name": "live",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "nftIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "EndAsyncToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getIdentifier",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProjectIdentifier",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProjectInfo",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "project_id",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "project_type",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "registry",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "country",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "region",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "methodology",
+            "type": "string"
+          },
+          {
+            "internalType": "uint64",
+            "name": "period_start",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "period_end",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          },
+          {
+            "internalType": "string",
+            "name": "uri",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "ac",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct ProjectData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVintage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "identifier",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_prefix",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_identifier",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_vintage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_projectKey",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_orchestratorAddress",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nftFromId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "offset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "orchestratorAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "projectKey",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vintage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
 ]

--- a/lib/abis/C3ProjectTokenFactory.json
+++ b/lib/abis/C3ProjectTokenFactory.json
@@ -1,669 +1,897 @@
 [
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "previousAdmin",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "newAdmin",
-                "type": "address"
-            }
-        ],
-        "name": "AdminChanged",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "previousAdmin",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newAdmin",
+          "type": "address"
+        }
+      ],
+      "name": "AdminChanged",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "beacon",
-                "type": "address"
-            }
-        ],
-        "name": "BeaconUpgraded",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "beacon",
+          "type": "address"
+        }
+      ],
+      "name": "BeaconUpgraded",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "projectName",
-                "type": "string"
-            },
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "tokenAddress",
-                "type": "address"
-            }
-        ],
-        "name": "NewTokenProject",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "fromToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "beneficiary",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_transferee",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_reason",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "live",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "success",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "nftIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "EndAsyncToken",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "projectName",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "tokenAddress",
+          "type": "address"
+        }
+      ],
+      "name": "NewTokenProject",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "Paused",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "previousAdminRole",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "newAdminRole",
-                "type": "bytes32"
-            }
-        ],
-        "name": "RoleAdminChanged",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "RoleGranted",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            }
-        ],
-        "name": "RoleRevoked",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "Unpaused",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
     },
     {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "implementation",
-                "type": "address"
-            }
-        ],
-        "name": "Upgraded",
-        "type": "event"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "fromToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "beneficiary",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_transferee",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_reason",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "live",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "StartAsyncToken",
+      "type": "event"
     },
     {
-        "inputs": [],
-        "name": "DEFAULT_ADMIN_ROLE",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
     },
     {
-        "inputs": [],
-        "name": "SUPERVISOR_ROLE",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "implementation",
+          "type": "address"
+        }
+      ],
+      "name": "Upgraded",
+      "type": "event"
     },
     {
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "_project",
-                "type": "string"
-            },
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
-        ],
-        "name": "checkProject",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "_registry",
-                "type": "string"
-            },
-            {
-                "internalType": "string",
-                "name": "_project",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_vintage",
-                "type": "uint256"
-            }
-        ],
-        "name": "getProjectVintageAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "SUPERVISOR_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "getProjectsDeployedAddresses",
-        "outputs": [
-            {
-                "internalType": "address[]",
-                "name": "",
-                "type": "address[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_project",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "checkProject",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            }
-        ],
-        "name": "getRoleAdmin",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "fromToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "beneficiary",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "_transferee",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_reason",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "live",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "status",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "nftIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "emitEndAsyncToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "grantRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "fromToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "beneficiary",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "_transferee",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_reason",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "live",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "emitStartAsyncToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "hasRole",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_registry",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_project",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_vintage",
+          "type": "uint256"
+        }
+      ],
+      "name": "getProjectVintageAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [],
+      "name": "getProjectsDeployedAddresses",
+      "outputs": [
+        {
+          "internalType": "address[]",
+          "name": "",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "isSupervisor",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "isIndeed",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
-        ],
-        "name": "isTokenExists",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "_registry",
-                "type": "string"
-            },
-            {
-                "internalType": "string",
-                "name": "_project",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_vintage",
-                "type": "uint256"
-            }
-        ],
-        "name": "newToken",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "orchestratorAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "isSupervisor",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isIndeed",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "pause",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "isTokenExists",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "paused",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_registry",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_project",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_vintage",
+          "type": "uint256"
+        }
+      ],
+      "name": "newToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "_registry",
-                "type": "string"
-            },
-            {
-                "internalType": "string",
-                "name": "_project",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_vintage",
-                "type": "uint256"
-            }
-        ],
-        "name": "projectHasToken",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "orchestratorAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "projectProxyToken",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "projectsDeployedAddresses",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "pause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "renounceRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_registry",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_project",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_vintage",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectHasToken",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "bytes32",
-                "name": "role",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "revokeRole",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [],
+      "name": "projectProxyToken",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_address",
-                "type": "address"
-            }
-        ],
-        "name": "setProjectProxyToken",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectsDeployedAddresses",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "interfaceId",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "_registry",
-                "type": "string"
-            },
-            {
-                "internalType": "string",
-                "name": "_project",
-                "type": "string"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_vintage",
-                "type": "uint256"
-            }
-        ],
-        "name": "symbolFactory",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "pure",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [],
-        "name": "unpause",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "setProjectProxyToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newImplementation",
-                "type": "address"
-            }
-        ],
-        "name": "upgradeTo",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newImplementation",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "data",
-                "type": "bytes"
-            }
-        ],
-        "name": "upgradeToAndCall",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "_registry",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_project",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_vintage",
+          "type": "uint256"
+        }
+      ],
+      "name": "symbolFactory",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newImplementation",
+          "type": "address"
+        }
+      ],
+      "name": "upgradeTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newImplementation",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "upgradeToAndCall",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
     }
-]
+  ]

--- a/lib/utils/Constants.ts
+++ b/lib/utils/Constants.ts
@@ -112,7 +112,8 @@ export const NFT_CO2COMPOUND_INIT_TIMESTAMP = BigInt.fromString('1638486000') //
 export const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
 
 // Klima Infinity Addresses
-export const KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0xe6d0C3172bd2964bB632C00D45b1CF260d997dA5') //mumbai
+export const KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0xac298CD34559B9AcfaedeA8344a977eceff1C0Fd') // polygon
+export const AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0x5505a7b6ced40a41882a38fc11e2f8bcab2b46f7') //amoy
 export const KLIMA_INFINITY_DIAMOND = Address.fromString('0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8') //mumbai
 
 // Other ecosystem addresses

--- a/lib/utils/Constants.ts
+++ b/lib/utils/Constants.ts
@@ -112,8 +112,8 @@ export const NFT_CO2COMPOUND_INIT_TIMESTAMP = BigInt.fromString('1638486000') //
 export const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000')
 
 // Klima Infinity Addresses
-export const KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0xac298cd34559b9acfaedea8344a977eceff1c0fd')
-export const KLIMA_INFINITY_DIAMOND = Address.fromString('0x8cE54d9625371fb2a068986d32C85De8E6e995f8')
+export const KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0xe6d0C3172bd2964bB632C00D45b1CF260d997dA5') //mumbai
+export const KLIMA_INFINITY_DIAMOND = Address.fromString('0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8') //mumbai
 
 // Other ecosystem addresses
 export const TOUCAN_REGEN_BRIDGE = Address.fromString('0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC')

--- a/lib/utils/Constants.ts
+++ b/lib/utils/Constants.ts
@@ -114,9 +114,10 @@ export const ZERO_ADDRESS = Address.fromString('0x000000000000000000000000000000
 // Klima Infinity Addresses
 export const KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0xac298CD34559B9AcfaedeA8344a977eceff1C0Fd') // polygon
 export const AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT = Address.fromString('0x5505a7b6ced40a41882a38fc11e2f8bcab2b46f7') //amoy
-export const KLIMA_INFINITY_DIAMOND = Address.fromString('0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8') //mumbai
+export const KLIMA_INFINITY_DIAMOND = Address.fromString('0x8cE54d9625371fb2a068986d32C85De8E6e995f8') //mumbai
 
 // Other ecosystem addresses
+export const C3_VERIFIED_CARBON_UNITS_OFFSET = Address.fromString('0x7b364DFc0e085468aFDe869DF20036D80b8868e7') 
 export const TOUCAN_REGEN_BRIDGE = Address.fromString('0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC')
 export const TOUCAN_CROSS_CHAIN_MESSENGER = Address.fromString('0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf')
 export const ICR_MIGRATION_BLOCK = BigInt.fromI32(55149940)

--- a/polygon-digital-carbon/networkConfig/polygon-amoy-local.json
+++ b/polygon-digital-carbon/networkConfig/polygon-amoy-local.json
@@ -61,8 +61,8 @@
       "startBlock": "7667754"
     },
     "RetireC3Carbon": {
-      "address": "0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff",
-      "startBlock": "7667754"
+      "address": "0x53AC0d9F5985551C1f0ca98665d870365D1c6Ead",
+      "startBlock": "7161008"
     },
     "KlimaInfinity": {
       "address": "0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54",

--- a/polygon-digital-carbon/networkConfig/polygon-amoy-local.json
+++ b/polygon-digital-carbon/networkConfig/polygon-amoy-local.json
@@ -1,28 +1,28 @@
 {
-    "network": "mumbai",
+    "network": "mainnet",
     "ToucanCarbonOffsetsFactory": {
       "address": "0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "ToucanCarbonOffsetBatch": {
       "address": "0x8A4d7458dDe3023A3B24225D62087701A88b09DD",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "BCT": {
       "address": "0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "NCT": {
       "address": "0xD838290e877E0188a4A44700463419ED96c16107",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "ToucanCrossChainMessenger": {
       "address": "0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "ToucanRegenBridge": {
       "address": "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "MossCarbon": {
       "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
@@ -30,43 +30,43 @@
     },
     "MossCarbonOffset": {
       "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "C3ProjectTokenFactory": {
-      "address": "0x3bc4ff4787c0f7cd83efb424176f559a00cf28c3",
-      "startBlock": "47284985"
+      "address": "0xd0CAE7819FA604ADB8C5c7A2685E6324b9c5417C",
+      "startBlock": "6827036"
     },
     "UBO": {
-      "address": "0x1c08ed3ff245de937a6414c2c39e372f2640f5f8",
-      "startBlock": "47284985"
+      "address": "0xd9cf88c9993AEf429160c7D725f9aFB4E25e2733",
+      "startBlock": "6827291"
     },
     "NBO": {
-      "address": "0x28d5158d45ec651133fac4c858bed65252ed5b7b",
-      "startBlock": "47284985"
+      "address": "0x71Fb8a17b8DF0D6e3f14F0A955eC7da8140f640A",
+      "startBlock": "6827303"
     },
     "C3-Offset": {
-      "address": "0xddafb3df0e464cd3252d50da405909185a7e1fbf",
-      "startBlock": "47284985"
+      "address": "0x282f92B498744ae357403e0e692646104fCB1dfc",
+      "startBlock": "6827054"
     },
     "ICRCarbonContractRegistry": {
       "address": "0x825cccb05d82fcd0381e523116a03b9301e91c61",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "RetireToucanCarbon": {
       "address": "0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "RetireMossCarbon": {
       "address": "0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "RetireC3Carbon": {
       "address": "0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff",
-      "startBlock": "47284985"
+      "startBlock": "7667754"
     },
     "KlimaInfinity": {
-      "address": "0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8",
-      "startBlock": "47284985"
+      "address": "0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54",
+      "startBlock": "7161009"
     },
     "sKlimaERC20V1": {
       "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",

--- a/polygon-digital-carbon/networkConfig/polygon-amoy.json
+++ b/polygon-digital-carbon/networkConfig/polygon-amoy.json
@@ -1,0 +1,76 @@
+{
+    "network": "polygon-amoy",
+    "ToucanCarbonOffsetsFactory": {
+      "address": "0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8",
+      "startBlock": "7667754"
+    },
+    "ToucanCarbonOffsetBatch": {
+      "address": "0x8A4d7458dDe3023A3B24225D62087701A88b09DD",
+      "startBlock": "7667754"
+    },
+    "BCT": {
+      "address": "0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5",
+      "startBlock": "7667754"
+    },
+    "NCT": {
+      "address": "0xD838290e877E0188a4A44700463419ED96c16107",
+      "startBlock": "7667754"
+    },
+    "ToucanCrossChainMessenger": {
+      "address": "0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf",
+      "startBlock": "7667754"
+    },
+    "ToucanRegenBridge": {
+      "address": "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC",
+      "startBlock": "7667754"
+    },
+    "MossCarbon": {
+      "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
+      "startBlock": "23193932"
+    },
+    "MossCarbonOffset": {
+      "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
+      "startBlock": "7667754"
+    },
+    "C3ProjectTokenFactory": {
+      "address": "0xd0CAE7819FA604ADB8C5c7A2685E6324b9c5417C",
+      "startBlock": "6827036"
+    },
+    "UBO": {
+      "address": "0xd9cf88c9993AEf429160c7D725f9aFB4E25e2733",
+      "startBlock": "6827291"
+    },
+    "NBO": {
+      "address": "0x71Fb8a17b8DF0D6e3f14F0A955eC7da8140f640A",
+      "startBlock": "6827303"
+    },
+    "C3-Offset": {
+      "address": "0x282f92B498744ae357403e0e692646104fCB1dfc",
+      "startBlock": "6827054"
+    },
+    "ICRCarbonContractRegistry": {
+      "address": "0x825cccb05d82fcd0381e523116a03b9301e91c61",
+      "startBlock": "7667754"
+    },
+    "RetireToucanCarbon": {
+      "address": "0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca",
+      "startBlock": "7667754"
+    },
+    "RetireMossCarbon": {
+      "address": "0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5",
+      "startBlock": "7667754"
+    },
+    "RetireC3Carbon": {
+      "address": "0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff",
+      "startBlock": "7667754"
+    },
+    "KlimaInfinity": {
+      "address": "0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54",
+      "startBlock": "7161009"
+    },
+    "sKlimaERC20V1": {
+      "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
+      "startBlock": "20190686"
+    }
+  }
+  

--- a/polygon-digital-carbon/networkConfig/polygon-amoy.json
+++ b/polygon-digital-carbon/networkConfig/polygon-amoy.json
@@ -26,7 +26,7 @@
     },
     "MossCarbon": {
       "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
-      "startBlock": "23193932"
+      "startBlock": "7667754"
     },
     "MossCarbonOffset": {
       "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
@@ -70,7 +70,7 @@
     },
     "sKlimaERC20V1": {
       "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
-      "startBlock": "20190686"
+      "startBlock": "7667754"
     }
   }
   

--- a/polygon-digital-carbon/networkConfig/polygon-amoy.json
+++ b/polygon-digital-carbon/networkConfig/polygon-amoy.json
@@ -1,76 +1,75 @@
 {
-    "network": "polygon-amoy",
-    "ToucanCarbonOffsetsFactory": {
-      "address": "0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8",
-      "startBlock": "7667754"
-    },
-    "ToucanCarbonOffsetBatch": {
-      "address": "0x8A4d7458dDe3023A3B24225D62087701A88b09DD",
-      "startBlock": "7667754"
-    },
-    "BCT": {
-      "address": "0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5",
-      "startBlock": "7667754"
-    },
-    "NCT": {
-      "address": "0xD838290e877E0188a4A44700463419ED96c16107",
-      "startBlock": "7667754"
-    },
-    "ToucanCrossChainMessenger": {
-      "address": "0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf",
-      "startBlock": "7667754"
-    },
-    "ToucanRegenBridge": {
-      "address": "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC",
-      "startBlock": "7667754"
-    },
-    "MossCarbon": {
-      "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
-      "startBlock": "7667754"
-    },
-    "MossCarbonOffset": {
-      "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
-      "startBlock": "7667754"
-    },
-    "C3ProjectTokenFactory": {
-      "address": "0xd0CAE7819FA604ADB8C5c7A2685E6324b9c5417C",
-      "startBlock": "6827036"
-    },
-    "UBO": {
-      "address": "0xd9cf88c9993AEf429160c7D725f9aFB4E25e2733",
-      "startBlock": "6827291"
-    },
-    "NBO": {
-      "address": "0x71Fb8a17b8DF0D6e3f14F0A955eC7da8140f640A",
-      "startBlock": "6827303"
-    },
-    "C3-Offset": {
-      "address": "0x282f92B498744ae357403e0e692646104fCB1dfc",
-      "startBlock": "6827054"
-    },
-    "ICRCarbonContractRegistry": {
-      "address": "0x825cccb05d82fcd0381e523116a03b9301e91c61",
-      "startBlock": "7667754"
-    },
-    "RetireToucanCarbon": {
-      "address": "0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca",
-      "startBlock": "7667754"
-    },
-    "RetireMossCarbon": {
-      "address": "0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5",
-      "startBlock": "7667754"
-    },
-    "RetireC3Carbon": {
-      "address": "0x53AC0d9F5985551C1f0ca98665d870365D1c6Ead",
-      "startBlock": "7161008"
-    },
-    "KlimaInfinity": {
-      "address": "0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54",
-      "startBlock": "7161009"
-    },
-    "sKlimaERC20V1": {
-      "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
-      "startBlock": "7667754"
-    }
+  "network": "polygon-amoy",
+  "ToucanCarbonOffsetsFactory": {
+    "address": "0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8",
+    "startBlock": "7667754"
+  },
+  "ToucanCarbonOffsetBatch": {
+    "address": "0x8A4d7458dDe3023A3B24225D62087701A88b09DD",
+    "startBlock": "7667754"
+  },
+  "BCT": {
+    "address": "0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5",
+    "startBlock": "7667754"
+  },
+  "NCT": {
+    "address": "0xD838290e877E0188a4A44700463419ED96c16107",
+    "startBlock": "7667754"
+  },
+  "ToucanCrossChainMessenger": {
+    "address": "0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf",
+    "startBlock": "7667754"
+  },
+  "ToucanRegenBridge": {
+    "address": "0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC",
+    "startBlock": "7667754"
+  },
+  "MossCarbon": {
+    "address": "0xaa7dbd1598251f856c12f63557a4c4397c253cea",
+    "startBlock": "7667754"
+  },
+  "MossCarbonOffset": {
+    "address": "0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8",
+    "startBlock": "7667754"
+  },
+  "C3ProjectTokenFactory": {
+    "address": "0xd0CAE7819FA604ADB8C5c7A2685E6324b9c5417C",
+    "startBlock": "6827036"
+  },
+  "UBO": {
+    "address": "0xd9cf88c9993AEf429160c7D725f9aFB4E25e2733",
+    "startBlock": "6827291"
+  },
+  "NBO": {
+    "address": "0x71Fb8a17b8DF0D6e3f14F0A955eC7da8140f640A",
+    "startBlock": "6827303"
+  },
+  "C3-Offset": {
+    "address": "0x282f92B498744ae357403e0e692646104fCB1dfc",
+    "startBlock": "6827054"
+  },
+  "ICRCarbonContractRegistry": {
+    "address": "0x825cccb05d82fcd0381e523116a03b9301e91c61",
+    "startBlock": "7667754"
+  },
+  "RetireToucanCarbon": {
+    "address": "0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca",
+    "startBlock": "7667754"
+  },
+  "RetireMossCarbon": {
+    "address": "0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5",
+    "startBlock": "7667754"
+  },
+  "RetireC3Carbon": {
+    "address": "0x53AC0d9F5985551C1f0ca98665d870365D1c6Ead",
+    "startBlock": "7161008"
+  },
+  "KlimaInfinity": {
+    "address": "0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54",
+    "startBlock": "7161009"
+  },
+  "sKlimaERC20V1": {
+    "address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
+    "startBlock": "7667754"
   }
-  
+}

--- a/polygon-digital-carbon/networkConfig/polygon-amoy.json
+++ b/polygon-digital-carbon/networkConfig/polygon-amoy.json
@@ -61,8 +61,8 @@
       "startBlock": "7667754"
     },
     "RetireC3Carbon": {
-      "address": "0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff",
-      "startBlock": "7667754"
+      "address": "0x53AC0d9F5985551C1f0ca98665d870365D1c6Ead",
+      "startBlock": "7161008"
     },
     "KlimaInfinity": {
       "address": "0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54",

--- a/polygon-digital-carbon/package.json
+++ b/polygon-digital-carbon/package.json
@@ -7,6 +7,8 @@
     "codegen": "rm -rf ./generated && graph codegen",
     "test": "graph test",
     "build": "graph build",
+    "prepare-polygon-amoy": "npx mustache networkConfig/polygon-amoy.json subgraph.template.yaml > subgraph.yaml",
+    "prepare-debug": "npx mustache networkConfig/debug.json subgraph.template.yaml > subgraph.yaml",
     "prepare-matic": "npx mustache networkConfig/matic.json subgraph.template.yaml > subgraph.yaml",
     "prepare-mumbai": "npx mustache networkConfig/mumbai.json subgraph.template.yaml > subgraph.yaml",
     "create-local": "graph create --node http://127.0.0.1:8020 polygon-carbon",
@@ -18,7 +20,8 @@
     "deploy-version": "graph deploy --ipfs $npm_config_ipfs --node $npm_config_node --version-label $npm_config_label polygon-carbon",
     "deploy-staging": "graph deploy --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/ polygon-carbon",
     "deploy-hosted": "graph deploy --product hosted-service $npm_config_path",
-    "deploy-tufnel": "yarn codegen && yarn build && graph deploy --product hosted-service psparacino/split-protocol"
+    "deploy-tufnel": "yarn prepare-matic && yarn codegen && yarn build && graph deploy --studio jcredit-testing-mainnet-grafts",
+    "deploy-tufnel-amoy": "yarn prepare-polygon-amoy && yarn codegen && yarn build && graph deploy --studio async-retires-amoy"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.69.1",

--- a/polygon-digital-carbon/package.json
+++ b/polygon-digital-carbon/package.json
@@ -17,7 +17,8 @@
     "deploy-args": "graph deploy --ipfs $npm_config_ipfs --node $npm_config_node polygon-carbon",
     "deploy-version": "graph deploy --ipfs $npm_config_ipfs --node $npm_config_node --version-label $npm_config_label polygon-carbon",
     "deploy-staging": "graph deploy --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/ polygon-carbon",
-    "deploy-hosted": "graph deploy --product hosted-service $npm_config_path"
+    "deploy-hosted": "graph deploy --product hosted-service $npm_config_path",
+    "deploy-tufnel": "yarn codegen && yarn build && graph deploy --product hosted-service psparacino/split-protocol"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.69.1",

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -388,7 +388,7 @@ type C3OffsetRequest @entity {
   "Request ID"
   id: ID!
   index: BigInt!
-  c3OffsetNftIndex: BigInt!
+  c3OffsetNftIndex: BigInt
   status: BridgeStatus!
   retire: Retire
   provenance: ProvenanceRecord
@@ -667,5 +667,3 @@ type HoldingDailySnapshot @entity {
   "Amount currently held in native units"
   amount: BigInt!
 }
-
-

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -33,6 +33,7 @@ enum ProvenanceType {
 }
 
 enum BridgeStatus {
+  AWAITING
   PENDING
   COMPLETED
 }

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -32,6 +32,11 @@ enum ProvenanceType {
   RETIREMENT
 }
 
+enum BridgeStatus {
+  PENDING
+  COMPLETED
+}
+
 type ProvenanceRecord @entity {
   "Token address - Holding address - increment"
   id: Bytes!
@@ -374,6 +379,15 @@ type ToucanBatch @entity {
 
   "Creation Transaction hash"
   creationTransactionHash: Bytes!
+}
+
+type C3OffsetRequest @entity {
+  "Request ID"
+  id: ID!
+  index: BigInt!
+  status: BridgeStatus!
+  retire: Retire
+  provenance: ProvenanceRecord
 }
 
 ##############################

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -348,6 +348,8 @@ type Retire @entity {
   ### Additional attributes if applicable ###
 
   klimaRetire: KlimaRetire @derivedFrom(field: "retire")
+
+  c3OffsetRequest: C3OffsetRequest
 }
 
 type KlimaRetire @entity {

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -391,6 +391,7 @@ type C3OffsetRequest @entity {
   status: BridgeStatus!
   retire: Retire
   provenance: ProvenanceRecord
+  tokenUri: String
 }
 
 ##############################

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -388,10 +388,18 @@ type C3OffsetRequest @entity {
   "Request ID"
   id: ID!
   index: BigInt!
+  c3OffsetNftIndex: BigInt!
   status: BridgeStatus!
   retire: Retire
   provenance: ProvenanceRecord
-  tokenUri: String
+  tokenURI: String!
+}
+
+# id is always and only safeguard
+type TokenURISafeguard @entity {
+  "Token URI"
+  id: ID!
+  requestsWithoutURI: [C3OffsetRequest!]!
 }
 
 ##############################
@@ -659,3 +667,5 @@ type HoldingDailySnapshot @entity {
   "Amount currently held in native units"
   amount: BigInt!
 }
+
+

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -4,14 +4,13 @@ import { C3Retired } from '../generated/RetireC3Carbon/RetireC3Carbon'
 import { CarbonRetired, CarbonRetired1 as CarbonRetiredTokenId } from '../generated/KlimaInfinity/KlimaInfinity'
 
 import { KlimaCarbonRetirements } from '../generated/RetireC3Carbon/KlimaCarbonRetirements'
-import { Address, BigInt, Bytes, log } from '@graphprotocol/graph-ts'
+import {  BigInt } from '@graphprotocol/graph-ts'
 import { loadOrCreateAccount } from './utils/Account'
 import { loadRetire } from './utils/Retire'
 import { ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { saveKlimaRetire } from './utils/KlimaRetire'
 import { KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
 import { ZERO_BI } from '../../lib/utils/Decimals'
-import { C3OffsetRequest } from '../generated/schema'
 
 export function handleMossRetired(event: MossRetired): void {
   // Ignore zero value retirements
@@ -107,12 +106,6 @@ export function handleC3Retired(event: C3Retired): void {
 }
 
 export function handleCarbonRetired(event: CarbonRetired): void {
-  log.info('asd handleCarbonRetired ; hash: {} TxIndex2: {}; LogIndex: {} Block: {}', [
-    event.transaction.hash.toHexString(),
-    event.transaction.index.toString(),
-    event.logIndex.toString(),
-    event.block.number.toString(),
-  ])
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
@@ -120,35 +113,17 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
-  let retiringAccount = loadOrCreateAccount(event.params.retiringAddress)
-  let retiringAddress = event.params.retiringAddress
+  loadOrCreateAccount(event.params.retiringAddress)
   loadOrCreateAccount(event.params.beneficiaryAddress)
 
-  log.info('qwe retireIdRetired: {}, retiringAddress: {}', [
-    sender.id.concatI32(sender.totalRetirements - 1).toHexString(),
-    retiringAddress.toHexString(),
-  ])
-
-  let retireId: Bytes
-
-  // check for C3OffsetRequest
-  let request = C3OffsetRequest.load(retiringAddress.concatI32(retiringAccount.totalRetirements).toHexString())
-
-  if (request != null && request.status == 'PENDING') {
-    retireId = retiringAddress.concatI32(retiringAccount.totalRetirements)
-  } else {
-    retireId = sender.id.concatI32(sender.totalRetirements - 1)
-  }
-  log.info('qwe retireId: {}, retiringAddress: {}', [retireId.toHexString(), retiringAddress.toHexString()])
-
-  let retire = loadRetire(retireId)
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
   retire.source = 'KLIMA'
   retire.beneficiaryAddress = event.params.beneficiaryAddress
   retire.beneficiaryName = event.params.beneficiaryString
-  retire.retiringAddress = retiringAddress
+  retire.retiringAddress = event.params.retiringAddress
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
 

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -11,12 +11,16 @@ import { AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT, ZERO_ADDRESS } from '../../lib/
 import { saveKlimaRetire } from './utils/KlimaRetire'
 import { KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
 import { ZERO_BI } from '../../lib/utils/Decimals'
+import { getRetirementsContractAddress } from '../utils/getRetirementsContractAddress'
 
 export function handleMossRetired(event: MossRetired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
+  let network = dataSource.network()
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let retirementsContractAddress = getRetirementsContractAddress(network)
+
+  let klimaRetirements = KlimaCarbonRetirements.bind(retirementsContractAddress)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -46,8 +50,11 @@ export function handleMossRetired(event: MossRetired): void {
 export function handleToucanRetired(event: ToucanRetired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
+  let network = dataSource.network()
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let retirementsContractAddress = getRetirementsContractAddress(network)
+  let klimaRetirements = KlimaCarbonRetirements.bind(retirementsContractAddress)
+
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -78,8 +85,10 @@ export function handleC3Retired(event: C3Retired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
-  // let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
-  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let network = dataSource.network()
+  let retirementsContractAddress = getRetirementsContractAddress(network)
+
+  let klimaRetirements = KlimaCarbonRetirements.bind(retirementsContractAddress)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -117,11 +126,10 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
   let network = dataSource.network()
-  log.info('handleCarbonRetired network: {}', [network])
-  let retireContractAddress =
-    network == 'matic' ? KLIMA_CARBON_RETIREMENTS_CONTRACT : AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(retireContractAddress)
+  let retirementsContractAddress = getRetirementsContractAddress(network)
+
+  let klimaRetirements = KlimaCarbonRetirements.bind(retirementsContractAddress)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -151,8 +159,10 @@ export function handleCarbonRetired(event: CarbonRetired): void {
 export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
+  let network = dataSource.network()
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let retirementsContractAddress = getRetirementsContractAddress(network)
+  let klimaRetirements = KlimaCarbonRetirements.bind(retirementsContractAddress)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -107,7 +107,8 @@ export function handleC3Retired(event: C3Retired): void {
 }
 
 export function handleCarbonRetired(event: CarbonRetired): void {
-  log.info('asd Handler2 ; TxIndex2: {}; LogIndex: {} Block: {}', [
+  log.info('asd handleCarbonRetired ; hash: {} TxIndex2: {}; LogIndex: {} Block: {}', [
+    event.transaction.hash.toHexString(),
     event.transaction.index.toString(),
     event.logIndex.toString(),
     event.block.number.toString(),

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -116,19 +116,19 @@ export function handleCarbonRetired(event: CarbonRetired): void {
 
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
+  let network = dataSource.network()
+  log.info('handleCarbonRetired network: {}', [network])
+  let retireContractAddress =
+    network == 'matic' ? KLIMA_CARBON_RETIREMENTS_CONTRACT : AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let klimaRetirements = KlimaCarbonRetirements.bind(retireContractAddress)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
-
-  log.info('asdf1 index: {} tokenAddress {}', [index.toString(), event.params.carbonToken.toHexString()])
 
   let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.retiringAddress)
   loadOrCreateAccount(event.params.beneficiaryAddress)
 
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
-
-  log.info('asdf2 retire: {}', [retire.id.toHexString()])
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -4,10 +4,10 @@ import { C3Retired } from '../generated/RetireC3Carbon/RetireC3Carbon'
 import { CarbonRetired, CarbonRetired1 as CarbonRetiredTokenId } from '../generated/KlimaInfinity/KlimaInfinity'
 
 import { KlimaCarbonRetirements } from '../generated/RetireC3Carbon/KlimaCarbonRetirements'
-import {  BigInt } from '@graphprotocol/graph-ts'
+import { BigInt, log, dataSource } from '@graphprotocol/graph-ts'
 import { loadOrCreateAccount } from './utils/Account'
 import { loadRetire } from './utils/Retire'
-import { ZERO_ADDRESS } from '../../lib/utils/Constants'
+import { AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT, ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { saveKlimaRetire } from './utils/KlimaRetire'
 import { KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
 import { ZERO_BI } from '../../lib/utils/Decimals'
@@ -16,7 +16,7 @@ export function handleMossRetired(event: MossRetired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -47,7 +47,7 @@ export function handleToucanRetired(event: ToucanRetired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -78,7 +78,8 @@ export function handleC3Retired(event: C3Retired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  // let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)
@@ -106,17 +107,28 @@ export function handleC3Retired(event: C3Retired): void {
 }
 
 export function handleCarbonRetired(event: CarbonRetired): void {
+  log.info('asdf: {} beneficary: {} retiring: {}', [
+    event.transaction.from.toHexString(),
+
+    event.params.beneficiaryAddress.toHexString(),
+    event.params.retiringAddress.toHexString(),
+  ])
+
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
+
+  log.info('asdf1 index: {} tokenAddress {}', [index.toString(), event.params.carbonToken.toHexString()])
 
   let sender = loadOrCreateAccount(event.transaction.from)
   loadOrCreateAccount(event.params.retiringAddress)
   loadOrCreateAccount(event.params.beneficiaryAddress)
 
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
+
+  log.info('asdf2 retire: {}', [retire.id.toHexString()])
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -140,7 +152,7 @@ export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): voi
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
 
-  let klimaRetirements = KlimaCarbonRetirements.bind(KLIMA_CARBON_RETIREMENTS_CONTRACT)
+  let klimaRetirements = KlimaCarbonRetirements.bind(AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT)
   let index = klimaRetirements.retirements(event.params.beneficiaryAddress).value0.minus(BigInt.fromI32(1))
 
   let sender = loadOrCreateAccount(event.transaction.from)

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -4,13 +4,14 @@ import { C3Retired } from '../generated/RetireC3Carbon/RetireC3Carbon'
 import { CarbonRetired, CarbonRetired1 as CarbonRetiredTokenId } from '../generated/KlimaInfinity/KlimaInfinity'
 
 import { KlimaCarbonRetirements } from '../generated/RetireC3Carbon/KlimaCarbonRetirements'
-import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { Address, BigInt, log } from '@graphprotocol/graph-ts'
 import { loadOrCreateAccount } from './utils/Account'
 import { loadRetire } from './utils/Retire'
 import { ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { saveKlimaRetire } from './utils/KlimaRetire'
 import { KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
 import { ZERO_BI } from '../../lib/utils/Decimals'
+import { C3OffsetRequest } from '../generated/schema'
 
 export function handleMossRetired(event: MossRetired): void {
   // Ignore zero value retirements
@@ -105,6 +106,8 @@ export function handleC3Retired(event: C3Retired): void {
   )
 }
 
+// this will need to exit if the retrement is the beginning of an async retirment
+// there shuld be a continatuion of this is for EndTokenAsync
 export function handleCarbonRetired(event: CarbonRetired): void {
   // Ignore zero value retirements
   if (event.params.retiredAmount == ZERO_BI) return
@@ -116,7 +119,8 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   loadOrCreateAccount(event.params.retiringAddress)
   loadOrCreateAccount(event.params.beneficiaryAddress)
 
-  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
+  let retireId = sender.id.concatI32(sender.totalRetirements - 1)
+  let retire = loadRetire(retireId)
 
   if (event.params.carbonPool != ZERO_ADDRESS) retire.pool = event.params.carbonPool
 
@@ -126,6 +130,17 @@ export function handleCarbonRetired(event: CarbonRetired): void {
   retire.retiringAddress = event.params.retiringAddress
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
+
+  // check if there is a pending Jcredit request for this retireId
+  let requestId = C3OffsetRequest.load(retireId.toHexString())
+
+  if (requestId != null) {
+    if (requestId.status == 'PENDING') {
+      // this event will fire directly after startTokenAsync, but we need to wait for endTokenAsync to create a klimaRetire
+      // this might not be necessary though. This can maybe just happen in endTokenAsync or VCUOMinted
+      return
+    }
+  }
 
   saveKlimaRetire(
     event.params.beneficiaryAddress,

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -1,4 +1,3 @@
-
 import {
   ICR_MIGRATION_BLOCK,
   KLIMA_INFINITY_DIAMOND,
@@ -6,7 +5,9 @@ import {
   ZERO_ADDRESS,
 } from '../../lib/utils/Constants'
 import { BIG_INT_1E18, ZERO_BI } from '../../lib/utils/Decimals'
-import { Address, log } from '@graphprotocol/graph-ts'
+
+import { Address, BigInt, log } from '@graphprotocol/graph-ts'
+
 import { C3OffsetNFT, VCUOMinted } from '../generated/C3-Offset/C3OffsetNFT'
 import { CarbonOffset } from '../generated/MossCarbonOffset/CarbonChain'
 import { RetiredVintage } from '../generated/templates/ICRProjectToken/ICRProjectToken'
@@ -91,7 +92,8 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   // This event only emits who receives the NFT and the token ID, although the data is stored.
   // Update associated entities using a call to retrieve the retirement details.
 
-  log.debug('asd Handler3 ; TxIndex3: {}; LogIndex: {} Block: {}', [
+  log.info('asd handleVCUOMinted ; hash: {} TxIndex3: {}; LogIndex: {} Block: {}', [
+    event.transaction.hash.toHexString(),
     event.transaction.index.toString(),
     event.logIndex.toString(),
     event.block.number.toString(),
@@ -100,10 +102,22 @@ export function handleVCUOMinted(event: VCUOMinted): void {
 
   let retireContract = C3OffsetNFT.bind(event.address)
 
-  let projectAddress = retireContract.list(event.params.tokenId).getProjectAddress()
-  let retireAmount = retireContract.list(event.params.tokenId).getAmount()
+  let projectAddress: Address = ZERO_ADDRESS
+  let retireAmount: BigInt = BigInt.fromI32(0)
 
-  let credit = loadCarbonCredit(projectAddress)
+  let addressResponse = retireContract.try_list(event.params.tokenId)
+  let amountResponse = retireContract.try_list(event.params.tokenId)
+
+  if (!addressResponse.reverted) {
+    projectAddress = addressResponse.value.getProjectAddress()
+  }
+  if (!amountResponse.reverted) {
+    retireAmount = amountResponse.value.getAmount()
+  }
+
+  // let credit = loadCarbonCredit(projectAddress)
+  //  this was failing on this txn: https://mumbai.polygonscan.com/tx/0x6c50f6ce6a42ab71de3374eb6092ed3573062d9c5b9220960bf9fa662785240d#eventlog
+  let credit = loadOrCreateCarbonCredit(projectAddress, 'C3', null)
 
   credit.retired = credit.retired.plus(retireAmount)
   credit.save()
@@ -120,7 +134,6 @@ export function handleVCUOMinted(event: VCUOMinted): void {
 
   let request = C3OffsetRequest.load(requestId)
 
-
   if (request != null && request.status == 'PENDING') {
     sender = paramsSender
     senderAddress = Address.fromBytes(paramsSender.id)
@@ -132,6 +145,20 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   }
 
   // Ensure account entities are created for all addresses
+
+  log.info('retirelogvalues {} {} {} {} {} {} {} {} {} {} {}', [
+    sender.id.concatI32(sender.totalRetirements).toHexString(),
+    projectAddress.toHexString(),
+    ZERO_ADDRESS.toHexString(),
+    'OTHER',
+    retireAmount.toString(),
+    event.params.sender.toHexString(),
+    '',
+    senderAddress.toHexString(),
+    '',
+    event.block.timestamp.toString(),
+    event.transaction.hash.toHexString(),
+  ])
 
   saveRetire(
     sender.id.concatI32(sender.totalRetirements),

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -1,4 +1,4 @@
-import { Address } from '@graphprotocol/graph-ts'
+
 import {
   ICR_MIGRATION_BLOCK,
   KLIMA_INFINITY_DIAMOND,
@@ -6,6 +6,7 @@ import {
   ZERO_ADDRESS,
 } from '../../lib/utils/Constants'
 import { BIG_INT_1E18, ZERO_BI } from '../../lib/utils/Decimals'
+import { Address, log } from '@graphprotocol/graph-ts'
 import { C3OffsetNFT, VCUOMinted } from '../generated/C3-Offset/C3OffsetNFT'
 import { CarbonOffset } from '../generated/MossCarbonOffset/CarbonChain'
 import { RetiredVintage } from '../generated/templates/ICRProjectToken/ICRProjectToken'
@@ -83,6 +84,8 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
   incrementAccountRetirements(senderAddress)
 }
 
+
+// this will also need to handle the async case of Jcredits
 export function handleVCUOMinted(event: VCUOMinted): void {
   // Currently the NFT minting is required and happens within every offset or offsetFor transaction made against a C3T
   // This event only emits who receives the NFT and the token ID, although the data is stored.

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -16,6 +16,7 @@ import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
 import { saveRetire } from './utils/Retire'
+import { Account, C3OffsetRequest } from '../generated/schema'
 
 export function saveToucanRetirement(event: Retired): void {
   // Disregard events with zero amount
@@ -85,11 +86,17 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
 }
 
 
-// this will also need to handle the async case of Jcredits
 export function handleVCUOMinted(event: VCUOMinted): void {
   // Currently the NFT minting is required and happens within every offset or offsetFor transaction made against a C3T
   // This event only emits who receives the NFT and the token ID, although the data is stored.
   // Update associated entities using a call to retrieve the retirement details.
+
+  log.debug('asd Handler3 ; TxIndex3: {}; LogIndex: {} Block: {}', [
+    event.transaction.index.toString(),
+    event.logIndex.toString(),
+    event.block.number.toString(),
+  ])
+  log.info('VCUO Minted: {} Sender: {}', [event.params.tokenId.toString(), event.params.sender.toHexString()])
 
   let retireContract = C3OffsetNFT.bind(event.address)
 
@@ -102,9 +109,28 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   credit.save()
 
   // Ensure account entities are created for all addresses
-  loadOrCreateAccount(event.params.sender)
-  let sender = loadOrCreateAccount(event.transaction.from)
-  let senderAddress = event.transaction.from
+  // ALERT: Changing this here.
+
+  let sender: Account
+  let senderAddress: Address
+
+  let paramsSender = loadOrCreateAccount(event.params.sender)
+
+  let requestId = paramsSender.id.concatI32(paramsSender.totalRetirements).toHexString()
+
+  let request = C3OffsetRequest.load(requestId)
+
+  if (request != null && request.status == 'PENDING') {
+    sender = paramsSender
+    senderAddress = Address.fromBytes(paramsSender.id)
+    loadOrCreateAccount(event.transaction.from)
+  } else {
+    sender = loadOrCreateAccount(event.transaction.from)
+    senderAddress = event.transaction.from
+    loadOrCreateAccount(event.params.sender)
+  }
+
+  // Ensure account entities are created for all addresses
 
   saveRetire(
     sender.id.concatI32(sender.totalRetirements),
@@ -119,6 +145,11 @@ export function handleVCUOMinted(event: VCUOMinted): void {
     event.block.timestamp,
     event.transaction.hash
   )
+  log.info('Retirement saved: {}, senderAddress {} hash: {}', [
+    event.params.tokenId.toString(),
+    senderAddress.toHexString(),
+    event.transaction.hash.toHexString(),
+  ])
 
   incrementAccountRetirements(senderAddress)
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -204,7 +204,8 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
   // Ignore retirements of zero value
   if (event.params.amount == ZERO_BI) return
 
-  loadOrCreateCarbonCredit(event.address, 'C3', null)
+  let credit = loadOrCreateCarbonCredit(event.address, 'C3', null)
+  credit.save()
 
   // ensure accounts are created for all addresses
   loadOrCreateAccount(event.params.beneficiary)
@@ -215,7 +216,7 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
 
   saveRetire(
     retireId,
-    event.address,
+    credit.id,
     ZERO_ADDRESS,
     'OTHER',
     event.params.amount,

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -10,13 +10,15 @@ import { Address, BigInt, log } from '@graphprotocol/graph-ts'
 
 import { C3OffsetNFT, VCUOMinted } from '../generated/C3-Offset/C3OffsetNFT'
 import { CarbonOffset } from '../generated/MossCarbonOffset/CarbonChain'
+import { EndAsyncToken, StartAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
 import { RetiredVintage } from '../generated/templates/ICRProjectToken/ICRProjectToken'
 import { Retired, Retired1 as Retired_1_4_0 } from '../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets'
-import { incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
+import { incrementAccountRetirements, loadOrCreateAccount, decrementAccountRetirements } from './utils/Account'
 import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit'
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
-import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
-import { saveRetire } from './utils/Retire'
+import { loadRetire, saveRetire } from './utils/Retire'
+import { Address, log } from '@graphprotocol/graph-ts'
+import { loadOrCreateC3OffsetBridgeRequest } from './utils/C3'
 
 export function saveToucanRetirement(event: Retired): void {
   // Disregard events with zero amount
@@ -196,4 +198,79 @@ export function saveICRRetirement(event: RetiredVintage): void {
   )
 
   incrementAccountRetirements(senderAddress)
+}
+
+export function saveStartAsyncToken(event: StartAsyncToken): void {
+  // Ignore retirements of zero value
+  if (event.params.amount == ZERO_BI) return
+
+  loadOrCreateCarbonCredit(event.address, 'C3', null)
+
+  // ensure accounts are created for all addresses
+  loadOrCreateAccount(event.params.beneficiary)
+  let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
+
+  let retireId = senderAddress.concatI32(sender.totalRetirements)
+
+  saveRetire(
+    retireId,
+    event.address,
+    ZERO_ADDRESS,
+    'OTHER',
+    event.params.amount,
+    event.params.beneficiary,
+    '',
+    senderAddress,
+    '',
+    event.block.timestamp,
+    event.transaction.hash,
+    'C3'
+  )
+
+  let eventAddress = event.address.toHexString()
+  let beneficiaryAddress = event.params.beneficiary.toHexString()
+  let requestId = `${eventAddress}-${beneficiaryAddress}-${event.params.index}`
+  let request = loadOrCreateC3OffsetBridgeRequest(requestId)
+
+  request.status = 'PENDING'
+  request.index = event.params.index
+  request.retire = retireId
+
+  let retire = loadRetire(retireId)
+
+  if (retire != null) {
+    request.provenance = retire.provenance
+  }
+
+  request.save()
+
+  incrementAccountRetirements(senderAddress)
+}
+
+export function completeC3OffsetRequest(event: EndAsyncToken): void {
+  let sender = loadOrCreateAccount(event.transaction.from)
+
+  let retireId = sender.id.concatI32(sender.totalRetirements)
+
+  let eventAddress = event.address.toHexString()
+  let beneficiaryAddress = event.params.beneficiary.toHexString()
+
+  let requestId = `${eventAddress}-${beneficiaryAddress}-${event.params.index}`
+  let request = loadOrCreateC3OffsetBridgeRequest(requestId)
+
+  if (request == null) {
+    log.error('No C3OffsetRequest found for retireId: {} hash: {}', [
+      retireId.toHexString(),
+      event.transaction.hash.toHexString(),
+    ])
+    return
+  } else {
+    if (request.status == 'PENDING') {
+      request.status = 'COMPLETED'
+      request.save()
+      /** decrement account retirements because the retire is double counted in VCUOMinted */
+      decrementAccountRetirements(Address.fromBytes(sender.id))
+    }
+  }
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -239,6 +239,8 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
   request.retire = retireId
 
   let retire = loadRetire(retireId)
+  retire.c3OffsetRequest = requestId
+  retire.save()
 
   if (retire != null) {
     request.provenance = retire.provenance

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -109,7 +109,6 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   let token = Token.load(projectAddress)
   if (token !== null && !token.symbol.startsWith('C3T-JCS') && !token.symbol.startsWith('C3T-ECO')) {
     log.info('token: {} request: {}', [token.symbol, event.params.tokenId.toString()])
-    log.info('fuckin hell {}', [event.params.tokenId.toString()])
 
     saveRetire(
       sender.id.concatI32(sender.totalRetirements),

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -7,7 +7,7 @@ import {
 import { BIG_INT_1E18, ZERO_BI } from '../../lib/utils/Decimals'
 import { C3OffsetNFT, VCUOMinted } from '../generated/C3-Offset/C3OffsetNFT'
 import { CarbonOffset } from '../generated/MossCarbonOffset/CarbonChain'
-import { EndAsyncToken, StartAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
+import { StartAsyncToken, EndAsyncToken } from '../generated/C3ProjectTokenFactory/C3ProjectTokenFactory'
 import { RetiredVintage } from '../generated/templates/ICRProjectToken/ICRProjectToken'
 import { Retired, Retired1 as Retired_1_4_0 } from '../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets'
 import { incrementAccountRetirements, loadOrCreateAccount, decrementAccountRetirements } from './utils/Account'
@@ -88,7 +88,7 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   // Currently the NFT minting is required and happens within every offset or offsetFor transaction made against a C3T
   // This event only emits who receives the NFT and the token ID, although the data is stored.
   // Update associated entities using a call to retrieve the retirement details.
-
+  log.info('fixt {}', [event.params.tokenId.toString()])
   let retireContract = C3OffsetNFT.bind(event.address)
 
   let projectAddress = retireContract.list(event.params.tokenId).getProjectAddress()
@@ -198,10 +198,12 @@ export function saveICRRetirement(event: RetiredVintage): void {
 }
 
 export function saveStartAsyncToken(event: StartAsyncToken): void {
+
+  log.info('start async event: {}', [event.params.amount.toString()])
   // Ignore retirements of zero value
   if (event.params.amount == ZERO_BI) return
 
-  let credit = loadOrCreateCarbonCredit(event.address, 'C3', null)
+  let credit = loadOrCreateCarbonCredit(event.params.fromToken, 'C3', null)
   credit.save()
 
   // ensure accounts are created for all addresses
@@ -210,6 +212,8 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
   let senderAddress = event.transaction.from
 
   let retireId = senderAddress.concatI32(sender.totalRetirements)
+
+  log.info('retireId 123: {} tokenAddress: {}', [retireId.toHexString(), event.params.fromToken.toHexString()])
 
   saveRetire(
     retireId,

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -17,6 +17,7 @@ import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
 import { saveRetire } from './utils/Retire'
 import { Account, C3OffsetRequest } from '../generated/schema'
+import { C3ProjectToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
 
 export function saveToucanRetirement(event: Retired): void {
   // Disregard events with zero amount
@@ -85,7 +86,6 @@ export function saveToucanRetirement_1_4_0(event: Retired_1_4_0): void {
   incrementAccountRetirements(senderAddress)
 }
 
-
 export function handleVCUOMinted(event: VCUOMinted): void {
   // Currently the NFT minting is required and happens within every offset or offsetFor transaction made against a C3T
   // This event only emits who receives the NFT and the token ID, although the data is stored.
@@ -119,6 +119,7 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   let requestId = paramsSender.id.concatI32(paramsSender.totalRetirements).toHexString()
 
   let request = C3OffsetRequest.load(requestId)
+
 
   if (request != null && request.status == 'PENDING') {
     sender = paramsSender

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -17,8 +17,6 @@ import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
 import { saveRetire } from './utils/Retire'
-import { Account, C3OffsetRequest } from '../generated/schema'
-import { C3ProjectToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
 
 export function saveToucanRetirement(event: Retired): void {
   // Disregard events with zero amount
@@ -92,73 +90,20 @@ export function handleVCUOMinted(event: VCUOMinted): void {
   // This event only emits who receives the NFT and the token ID, although the data is stored.
   // Update associated entities using a call to retrieve the retirement details.
 
-  log.info('asd handleVCUOMinted ; hash: {} TxIndex3: {}; LogIndex: {} Block: {}', [
-    event.transaction.hash.toHexString(),
-    event.transaction.index.toString(),
-    event.logIndex.toString(),
-    event.block.number.toString(),
-  ])
-  log.info('VCUO Minted: {} Sender: {}', [event.params.tokenId.toString(), event.params.sender.toHexString()])
-
   let retireContract = C3OffsetNFT.bind(event.address)
 
-  let projectAddress: Address = ZERO_ADDRESS
-  let retireAmount: BigInt = BigInt.fromI32(0)
+  let projectAddress = retireContract.list(event.params.tokenId).getProjectAddress()
+  let retireAmount = retireContract.list(event.params.tokenId).getAmount()
 
-  let addressResponse = retireContract.try_list(event.params.tokenId)
-  let amountResponse = retireContract.try_list(event.params.tokenId)
-
-  if (!addressResponse.reverted) {
-    projectAddress = addressResponse.value.getProjectAddress()
-  }
-  if (!amountResponse.reverted) {
-    retireAmount = amountResponse.value.getAmount()
-  }
-
-  // let credit = loadCarbonCredit(projectAddress)
-  //  this was failing on this txn: https://mumbai.polygonscan.com/tx/0x6c50f6ce6a42ab71de3374eb6092ed3573062d9c5b9220960bf9fa662785240d#eventlog
   let credit = loadOrCreateCarbonCredit(projectAddress, 'C3', null)
 
   credit.retired = credit.retired.plus(retireAmount)
   credit.save()
 
   // Ensure account entities are created for all addresses
-  // ALERT: Changing this here.
-
-  let sender: Account
-  let senderAddress: Address
-
-  let paramsSender = loadOrCreateAccount(event.params.sender)
-
-  let requestId = paramsSender.id.concatI32(paramsSender.totalRetirements).toHexString()
-
-  let request = C3OffsetRequest.load(requestId)
-
-  if (request != null && request.status == 'PENDING') {
-    sender = paramsSender
-    senderAddress = Address.fromBytes(paramsSender.id)
-    loadOrCreateAccount(event.transaction.from)
-  } else {
-    sender = loadOrCreateAccount(event.transaction.from)
-    senderAddress = event.transaction.from
-    loadOrCreateAccount(event.params.sender)
-  }
-
-  // Ensure account entities are created for all addresses
-
-  log.info('retirelogvalues {} {} {} {} {} {} {} {} {} {} {}', [
-    sender.id.concatI32(sender.totalRetirements).toHexString(),
-    projectAddress.toHexString(),
-    ZERO_ADDRESS.toHexString(),
-    'OTHER',
-    retireAmount.toString(),
-    event.params.sender.toHexString(),
-    '',
-    senderAddress.toHexString(),
-    '',
-    event.block.timestamp.toString(),
-    event.transaction.hash.toHexString(),
-  ])
+  loadOrCreateAccount(event.params.sender)
+  let sender = loadOrCreateAccount(event.transaction.from)
+  let senderAddress = event.transaction.from
 
   saveRetire(
     sender.id.concatI32(sender.totalRetirements),
@@ -173,11 +118,6 @@ export function handleVCUOMinted(event: VCUOMinted): void {
     event.block.timestamp,
     event.transaction.hash
   )
-  log.info('Retirement saved: {}, senderAddress {} hash: {}', [
-    event.params.tokenId.toString(),
-    senderAddress.toHexString(),
-    event.transaction.hash.toHexString(),
-  ])
 
   incrementAccountRetirements(senderAddress)
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -1,6 +1,6 @@
 import {
   ICR_MIGRATION_BLOCK,
-  KLIMA_INFINITY_DIAMOND,
+
   MCO2_ERC20_CONTRACT,
   ZERO_ADDRESS,
 } from '../../lib/utils/Constants'

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -5,9 +5,6 @@ import {
   ZERO_ADDRESS,
 } from '../../lib/utils/Constants'
 import { BIG_INT_1E18, ZERO_BI } from '../../lib/utils/Decimals'
-
-import { Address, BigInt, log } from '@graphprotocol/graph-ts'
-
 import { C3OffsetNFT, VCUOMinted } from '../generated/C3-Offset/C3OffsetNFT'
 import { CarbonOffset } from '../generated/MossCarbonOffset/CarbonChain'
 import { EndAsyncToken, StartAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -12,19 +12,16 @@ import {
 } from '../generated/templates/ICRProjectToken/ICRProjectToken'
 import { loadOrCreateHolding } from './utils/Holding'
 import { ZERO_BI } from '../../lib/utils/Decimals'
-import { incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
+import { decrementAccountRetirements, incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
 import { saveICRRetirement, saveToucanRetirement, saveToucanRetirement_1_4_0 } from './RetirementHandler'
 import { saveBridge } from './utils/Bridge'
 import { CarbonCredit, CrossChainBridge, C3OffsetRequest } from '../generated/schema'
 import { checkForCarbonPoolSnapshot, loadOrCreateCarbonPool } from './utils/CarbonPool'
 import { checkForCarbonPoolCreditSnapshot } from './utils/CarbonPoolCreditBalance'
 import { loadOrCreateEcosystem } from './utils/Ecosystem'
-import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
-import { StartAsyncToken, EndAsyncToken, C3ProjectToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
-import { loadRetire, saveRetire } from './utils/Retire'
-import { saveKlimaRetire } from './utils/KlimaRetire'
-import { KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
-import { KlimaCarbonRetirements } from '../generated/RetireC3Carbon/KlimaCarbonRetirements'
+import { recordProvenance } from './utils/Provenance'
+import { StartAsyncToken, EndAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
+import { saveRetire } from './utils/Retire'
 
 export function handleCreditTransfer(event: Transfer): void {
   recordTransfer(
@@ -263,14 +260,13 @@ function recordTransfer(
 }
 
 // asyncToken handling
-
 export function handleStartAsyncToken(event: StartAsyncToken): void {
   log.info('handleStartAsyncToken fired', [])
 
   // Ignore retirements of zero value
   if (event.params.amount == ZERO_BI) return
 
-  let credit = loadOrCreateCarbonCredit(event.address, 'C3', null)
+  loadOrCreateCarbonCredit(event.address, 'C3', null)
 
   // ensure accounts are created for all addresses
   loadOrCreateAccount(event.params.beneficiary)
@@ -279,14 +275,6 @@ export function handleStartAsyncToken(event: StartAsyncToken): void {
 
   // let recordId = updateProvenanceForRetirement(credit.id)
   let retireId = senderAddress.concatI32(sender.totalRetirements)
-
-  log.info('asd handleStartAsyncToken ; hash: {} TxIndex0: {}; LogIndex: {} Block: {} retireIdStart: {} ', [
-    event.transaction.hash.toHexString(),
-    event.transaction.index.toString(),
-    event.logIndex.toString(),
-    event.block.number.toString(),
-    senderAddress.concatI32(sender.totalRetirements).toHexString(),
-  ])
 
   saveRetire(
     retireId,
@@ -302,8 +290,13 @@ export function handleStartAsyncToken(event: StartAsyncToken): void {
     event.transaction.hash,
     'C3'
   )
-  log.info("retireId: {}", [retireId.toHexString()])
-  let request = new C3OffsetRequest(retireId.toHexString())
+
+  let eventAddress = event.address.toHexString()
+  let beneficiaryAddress = event.params.beneficiary.toHexString()
+
+  let requestId = `${eventAddress}-${beneficiaryAddress}-${event.params.index}`
+
+  let request = new C3OffsetRequest(requestId)
 
   request.status = 'PENDING'
   request.index = event.params.index
@@ -312,39 +305,35 @@ export function handleStartAsyncToken(event: StartAsyncToken): void {
 
   request.save()
 
-  log.info('C3OffsetRequest saved: {}', [request.id])
+  incrementAccountRetirements(senderAddress)
 }
-// Fix: sender or account won't always be who initiated the retire and thus can't be used for an id
+
 export function handleEndAsyncToken(event: EndAsyncToken): void {
   // load request and set status to completed
   log.info('handleEndAsyncToken fired', [])
 
-  let tokenContract = C3ProjectToken.bind(event.address)
-
-  let data = tokenContract.getAsyncData(event.params.index)
-
-  // && request.index == data.currentIndex
-
-  log.info('asd handleEndAsyncToken ; hash; {} TxIndex1: {}; LogIndex: {} Block: {}', [
-    event.transaction.hash.toHexString(),
-    event.transaction.index.toString(),
-    event.logIndex.toString(),
-    event.block.number.toString(),
-  ])
   let sender = loadOrCreateAccount(event.transaction.from)
 
   let retireId = sender.id.concatI32(sender.totalRetirements)
-  let request = C3OffsetRequest.load(retireId.toHexString())
 
-  // let retire = loadRetire(retireId)
+  let eventAddress = event.address.toHexString()
+  let beneficiaryAddress = event.params.beneficiary.toHexString()
+
+  let requestId = `${eventAddress}-${beneficiaryAddress}-${event.params.index}`
+  let request = C3OffsetRequest.load(requestId)
 
   if (request == null) {
-    log.error('No C3OffsetRequest found for retireId: {} hash: {}', [retireId.toHexString(), event.transaction.hash.toHexString()])
+    log.error('No C3OffsetRequest found for retireId: {} hash: {}', [
+      retireId.toHexString(),
+      event.transaction.hash.toHexString(),
+    ])
     return
   } else {
     if (request.status == 'PENDING') {
       request.status = 'COMPLETED'
       request.save()
+      /** decrement account retirements because the retire is double counted in VCUOMinted */
+      decrementAccountRetirements(Address.fromBytes(sender.id))
     }
   }
 }

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes, store } from '@graphprotocol/graph-ts'
+import { Address, BigInt, Bytes, log, store } from '@graphprotocol/graph-ts'
 import { ICR_MIGRATION_BLOCK, ICR_MIGRATION_HASHES, MCO2_ERC20_CONTRACT, ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { Transfer } from '../generated/BCT/ERC20'
 import { loadOrCreateCarbonCredit, updateICRCredit } from './utils/CarbonCredit'
@@ -12,7 +12,7 @@ import {
 } from '../generated/templates/ICRProjectToken/ICRProjectToken'
 import { loadOrCreateHolding } from './utils/Holding'
 import { ZERO_BI, BIG_INT_1E18 } from '../../lib/utils/Decimals'
-import { decrementAccountRetirements, incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
+import { loadOrCreateAccount } from './utils/Account'
 import {
   completeC3OffsetRequest,
   saveICRRetirement,
@@ -26,9 +26,7 @@ import { checkForCarbonPoolSnapshot, loadOrCreateCarbonPool } from './utils/Carb
 import { checkForCarbonPoolCreditSnapshot } from './utils/CarbonPoolCreditBalance'
 import { loadOrCreateEcosystem } from './utils/Ecosystem'
 import { recordProvenance } from './utils/Provenance'
-import { StartAsyncToken, EndAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
 import { createICRTokenWithCall } from './utils/Token'
-import { saveRetire } from './utils/Retire'
 
 export function handleCreditTransfer(event: Transfer): void {
   recordTransfer(
@@ -264,29 +262,4 @@ function recordTransfer(
 
     pool.save()
   }
-}
-
-// asyncToken handling
-
-export function handleStartAsyncToken(event: StartAsyncToken): void {
-  // Ignore retirements of zero value
-  if (event.params.amount == ZERO_BI) return
-
-  saveStartAsyncToken(event)
-
-  recordProvenance(
-    event.transaction.hash,
-    event.address,
-    null,
-    event.transaction.from,
-    ZERO_ADDRESS,
-    'RETIREMENT',
-    event.params.amount,
-    event.block.timestamp
-  )
-}
-
-export function handleEndAsyncToken(event: EndAsyncToken): void {
-  // load request and set status to completed
-  completeC3OffsetRequest(event)
 }

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -279,7 +279,7 @@ export function handleStartAsyncToken(event: StartAsyncToken): void {
     null,
     event.transaction.from,
     ZERO_ADDRESS,
-    'RETIRE',
+    'RETIREMENT',
     event.params.amount,
     event.block.timestamp
   )

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -14,9 +14,7 @@ import { loadOrCreateHolding } from './utils/Holding'
 import { ZERO_BI, BIG_INT_1E18 } from '../../lib/utils/Decimals'
 import { loadOrCreateAccount } from './utils/Account'
 import {
-  completeC3OffsetRequest,
   saveICRRetirement,
-  saveStartAsyncToken,
   saveToucanRetirement,
   saveToucanRetirement_1_4_0,
 } from './RetirementHandler'

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -13,7 +13,13 @@ import {
 import { loadOrCreateHolding } from './utils/Holding'
 import { ZERO_BI } from '../../lib/utils/Decimals'
 import { decrementAccountRetirements, incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
-import { saveICRRetirement, saveToucanRetirement, saveToucanRetirement_1_4_0 } from './RetirementHandler'
+import {
+  completeC3OffsetRequest,
+  saveICRRetirement,
+  saveStartAsyncToken,
+  saveToucanRetirement,
+  saveToucanRetirement_1_4_0,
+} from './RetirementHandler'
 import { saveBridge } from './utils/Bridge'
 import { CarbonCredit, CrossChainBridge, C3OffsetRequest } from '../generated/schema'
 import { checkForCarbonPoolSnapshot, loadOrCreateCarbonPool } from './utils/CarbonPool'
@@ -260,80 +266,26 @@ function recordTransfer(
 }
 
 // asyncToken handling
-export function handleStartAsyncToken(event: StartAsyncToken): void {
-  log.info('handleStartAsyncToken fired', [])
 
+export function handleStartAsyncToken(event: StartAsyncToken): void {
   // Ignore retirements of zero value
   if (event.params.amount == ZERO_BI) return
 
-  loadOrCreateCarbonCredit(event.address, 'C3', null)
+  saveStartAsyncToken(event)
 
-  // ensure accounts are created for all addresses
-  loadOrCreateAccount(event.params.beneficiary)
-  let sender = loadOrCreateAccount(event.transaction.from)
-  let senderAddress = Address.fromBytes(sender.id)
-
-  // let recordId = updateProvenanceForRetirement(credit.id)
-  let retireId = senderAddress.concatI32(sender.totalRetirements)
-
-  saveRetire(
-    retireId,
-    event.address,
-    ZERO_ADDRESS,
-    'OTHER',
-    event.params.amount,
-    event.params.beneficiary,
-    '',
-    senderAddress,
-    '',
-    event.block.timestamp,
+  recordProvenance(
     event.transaction.hash,
-    'C3'
+    event.address,
+    null,
+    event.transaction.from,
+    ZERO_ADDRESS,
+    'RETIRE',
+    event.params.amount,
+    event.block.timestamp
   )
-
-  let eventAddress = event.address.toHexString()
-  let beneficiaryAddress = event.params.beneficiary.toHexString()
-
-  let requestId = `${eventAddress}-${beneficiaryAddress}-${event.params.index}`
-
-  let request = new C3OffsetRequest(requestId)
-
-  request.status = 'PENDING'
-  request.index = event.params.index
-  request.retire = retireId
-  // request.provenance = recordId
-
-  request.save()
-
-  incrementAccountRetirements(senderAddress)
 }
 
 export function handleEndAsyncToken(event: EndAsyncToken): void {
   // load request and set status to completed
-  log.info('handleEndAsyncToken fired', [])
-
-  let sender = loadOrCreateAccount(event.transaction.from)
-
-  let retireId = sender.id.concatI32(sender.totalRetirements)
-
-  let eventAddress = event.address.toHexString()
-  let beneficiaryAddress = event.params.beneficiary.toHexString()
-
-  let requestId = `${eventAddress}-${beneficiaryAddress}-${event.params.index}`
-  let request = C3OffsetRequest.load(requestId)
-
-  if (request == null) {
-    log.error('No C3OffsetRequest found for retireId: {} hash: {}', [
-      retireId.toHexString(),
-      event.transaction.hash.toHexString(),
-    ])
-    return
-  } else {
-    if (request.status == 'PENDING') {
-      request.status = 'COMPLETED'
-      request.save()
-      /** decrement account retirements because the retire is double counted in VCUOMinted */
-      decrementAccountRetirements(Address.fromBytes(sender.id))
-    }
-  }
+  completeC3OffsetRequest(event)
 }

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -21,7 +21,7 @@ import {
   saveToucanRetirement_1_4_0,
 } from './RetirementHandler'
 import { saveBridge } from './utils/Bridge'
-import { CarbonCredit, CrossChainBridge, C3OffsetRequest } from '../generated/schema'
+import { CarbonCredit, CrossChainBridge } from '../generated/schema'
 import { checkForCarbonPoolSnapshot, loadOrCreateCarbonPool } from './utils/CarbonPool'
 import { checkForCarbonPoolCreditSnapshot } from './utils/CarbonPoolCreditBalance'
 import { loadOrCreateEcosystem } from './utils/Ecosystem'

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -20,7 +20,7 @@ import { checkForCarbonPoolSnapshot, loadOrCreateCarbonPool } from './utils/Carb
 import { checkForCarbonPoolCreditSnapshot } from './utils/CarbonPoolCreditBalance'
 import { loadOrCreateEcosystem } from './utils/Ecosystem'
 import { recordProvenance, updateProvenanceForRetirement } from './utils/Provenance'
-import { StartAsyncToken, EndAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
+import { StartAsyncToken, EndAsyncToken, C3ProjectToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
 import { loadRetire, saveRetire } from './utils/Retire'
 import { saveKlimaRetire } from './utils/KlimaRetire'
 import { KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
@@ -315,6 +315,12 @@ export function handleStartAsyncToken(event: StartAsyncToken): void {
 export function handleEndAsyncToken(event: EndAsyncToken): void {
   // load request and set status to completed
   log.info('handleEndAsyncToken fired', [])
+
+  let tokenContract = C3ProjectToken.bind(event.address)
+
+  let data = tokenContract.getAsyncData(event.params.index)
+
+  // && request.index == data.currentIndex
 
   log.info('asd Handler1 ; TxIndex1: {}; LogIndex: {} Block: {}', [
     event.transaction.index.toString(),

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -11,7 +11,7 @@ import {
   ExAnteMinted,
 } from '../generated/templates/ICRProjectToken/ICRProjectToken'
 import { loadOrCreateHolding } from './utils/Holding'
-import { ZERO_BI } from '../../lib/utils/Decimals'
+import { ZERO_BI, BIG_INT_1E18 } from '../../lib/utils/Decimals'
 import { decrementAccountRetirements, incrementAccountRetirements, loadOrCreateAccount } from './utils/Account'
 import {
   completeC3OffsetRequest,
@@ -27,6 +27,7 @@ import { checkForCarbonPoolCreditSnapshot } from './utils/CarbonPoolCreditBalanc
 import { loadOrCreateEcosystem } from './utils/Ecosystem'
 import { recordProvenance } from './utils/Provenance'
 import { StartAsyncToken, EndAsyncToken } from '../generated/templates/C3ProjectToken/C3ProjectToken'
+import { createICRTokenWithCall } from './utils/Token'
 import { saveRetire } from './utils/Retire'
 
 export function handleCreditTransfer(event: Transfer): void {

--- a/polygon-digital-carbon/src/templates/C3ProjectTokenFactory.ts
+++ b/polygon-digital-carbon/src/templates/C3ProjectTokenFactory.ts
@@ -22,7 +22,6 @@ export function handleNewC3T(event: NewTokenProject): void {
 // asyncToken handling
 
 export function handleStartAsyncToken(event: StartAsyncToken): void {
-  log.info('zed {}', [event.params.amount.toString()])
   // Ignore retirements of zero value
   if (event.params.amount == ZERO_BI) return
 

--- a/polygon-digital-carbon/src/templates/C3ProjectTokenFactory.ts
+++ b/polygon-digital-carbon/src/templates/C3ProjectTokenFactory.ts
@@ -2,6 +2,13 @@ import { C3ProjectToken } from '../../generated/templates'
 import { NewTokenProject } from '../../generated/C3ProjectTokenFactory/C3ProjectTokenFactory'
 import { loadOrCreateCarbonCredit, updateCarbonCreditWithCall } from '../utils/CarbonCredit'
 import { createTokenWithCall } from '../utils/Token'
+import { log } from '@graphprotocol/graph-ts'
+import { ZERO_BI } from '../../../lib/utils/Decimals'
+import { saveStartAsyncToken } from '../RetirementHandler'
+import { recordProvenance } from '../utils/Provenance'
+import { ZERO_ADDRESS } from '../../../lib/utils/Constants'
+import { completeC3OffsetRequest } from '../RetirementHandler'
+import { StartAsyncToken, EndAsyncToken } from '../../generated/C3ProjectTokenFactory/C3ProjectTokenFactory'
 
 export function handleNewC3T(event: NewTokenProject): void {
   // Start indexing the C3T tokens; `event.params.tokenAddress` is the
@@ -10,4 +17,30 @@ export function handleNewC3T(event: NewTokenProject): void {
   loadOrCreateCarbonCredit(event.params.tokenAddress, 'C3', null)
   createTokenWithCall(event.params.tokenAddress)
   updateCarbonCreditWithCall(event.params.tokenAddress)
+}
+
+// asyncToken handling
+
+export function handleStartAsyncToken(event: StartAsyncToken): void {
+  log.info('zed {}', [event.params.amount.toString()])
+  // Ignore retirements of zero value
+  if (event.params.amount == ZERO_BI) return
+
+  saveStartAsyncToken(event)
+
+  recordProvenance(
+    event.transaction.hash,
+    event.params.fromToken,
+    null,
+    event.transaction.from,
+    ZERO_ADDRESS,
+    'RETIREMENT',
+    event.params.amount,
+    event.block.timestamp
+  )
+}
+
+export function handleEndAsyncToken(event: EndAsyncToken): void {
+  // load request and set status to completed
+  completeC3OffsetRequest(event)
 }

--- a/polygon-digital-carbon/src/templates/ICRCarbonContractRegistry.ts
+++ b/polygon-digital-carbon/src/templates/ICRCarbonContractRegistry.ts
@@ -4,7 +4,6 @@ import { loadOrCreateCarbonCredit } from '../utils/CarbonCredit'
 import { loadOrCreateCarbonProject } from '../utils/CarbonProject'
 import { Address, BigInt, log } from '@graphprotocol/graph-ts'
 import { ICR_PROJECT_INFO } from '../../../lib/utils/ICRProjectInfo'
-import { createICRTokenWithCall } from '../utils/Token'
 
 export function handleNewICC(event: ProjectCreated): void {
   // Start indexing the C3T tokens; `event.params.tokenAddress` is the

--- a/polygon-digital-carbon/src/utils/Account.ts
+++ b/polygon-digital-carbon/src/utils/Account.ts
@@ -17,3 +17,10 @@ export function incrementAccountRetirements(accountAddress: Address): void {
   account.totalRetirements += 1
   account.save()
 }
+
+export function decrementAccountRetirements(accountAddress: Address): void {
+  let account = loadOrCreateAccount(accountAddress)
+
+  account.totalRetirements -= 1
+  account.save()
+} 

--- a/polygon-digital-carbon/src/utils/C3.ts
+++ b/polygon-digital-carbon/src/utils/C3.ts
@@ -1,0 +1,15 @@
+import { BigInt } from '@graphprotocol/graph-ts'
+import { C3OffsetRequest } from '../../generated/schema'
+
+export function loadOrCreateC3OffsetBridgeRequest(requestId: string): C3OffsetRequest {
+  let request = C3OffsetRequest.load(requestId)
+
+  if (request == null) {
+    request = new C3OffsetRequest(requestId)
+    request.status = 'AWAITING'
+    request.index = BigInt.fromI32(0)
+    request.save()
+  }
+
+  return request;
+}

--- a/polygon-digital-carbon/src/utils/C3.ts
+++ b/polygon-digital-carbon/src/utils/C3.ts
@@ -8,6 +8,8 @@ export function loadOrCreateC3OffsetBridgeRequest(requestId: string): C3OffsetRe
     request = new C3OffsetRequest(requestId)
     request.status = 'AWAITING'
     request.index = BigInt.fromI32(0)
+    request.c3OffsetNftIndex = BigInt.fromI32(0)
+    request.tokenURI = ''
     request.save()
   }
 

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -71,15 +71,25 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
 
   let attributes = carbonCreditERC20.getProjectInfo()
 
+  log.info('C3 Project Info: {}', [attributes.registry.toString()])
+
   // Map to enum values
   let registry = ''
   if (attributes.registry == 'VCS') registry = 'VERRA'
   else if (attributes.registry == 'GS') registry = 'GOLD_STANDARD'
-  else if (attributes.registry == 'JCS' || 'JPN') registry = 'J_CREDIT'
+  else if (attributes.registry == 'JCS' || attributes.registry == 'JPN') registry = 'J_CREDIT'
   else if (attributes.registry == 'ACR') registry = 'AMERICAN_CARBON_REGISTRY'
   else if (attributes.registry == 'ECO') registry = 'ECO_REGISTRY'
 
-  let project = loadOrCreateCarbonProject(registry, attributes.registry + '-' + attributes.project_id)
+  let projectID: string;
+
+  if (attributes.registry == 'JCS' || attributes.registry == 'JPN') {
+    projectID = attributes.project_id.slice(0, attributes.project_id.length - 2)
+  } else {
+    projectID = attributes.project_id
+  }
+
+  let project = loadOrCreateCarbonProject(registry, attributes.registry + '-' + projectID)
 
   carbonCredit.project = project.id
   let vintageParsed = BigInt.fromI64(Date.UTC(carbonCreditERC20.getVintage().toI32(), 0) / 1000)
@@ -89,6 +99,11 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
 
   project.methodologies = attributes.methodology
   project.category = MethodologyCategories.getMethodologyCategory(project.methodologies)
+  project.country = attributes.country
+  project.category = attributes.project_type
+  project.region = attributes.region
+  project.methodologies = attributes.methodology
+  project.name = attributes.name
   project.save()
   return carbonCredit
 }

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
+import { Address, BigInt, Bytes, log } from '@graphprotocol/graph-ts'
 import { stdYearFromTimestampNew as stdYearFromTimestamp } from '../../../lib/utils/Dates'
 import { ZERO_BI } from '../../../lib/utils/Decimals'
 import { C3ProjectToken } from '../../generated/templates/C3ProjectToken/C3ProjectToken'

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -81,8 +81,10 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
   else if (attributes.registry == 'ACR') registry = 'AMERICAN_CARBON_REGISTRY'
   else if (attributes.registry == 'ECO') registry = 'ECO_REGISTRY'
 
-  let projectID: string;
+  let projectID: string
 
+  /** the last two charactes of a JCS or JPN project ID are a suffix id of
+   * the vintage and do not relate to the project itself */
   if (attributes.registry == 'JCS' || attributes.registry == 'JPN') {
     projectID = attributes.project_id.slice(0, attributes.project_id.length - 2)
   } else {

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -75,7 +75,8 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
   let registry = ''
   if (attributes.registry == 'VCS') registry = 'VERRA'
   else if (attributes.registry == 'GS') registry = 'GOLD_STANDARD'
-  else if (attributes.registry == 'JCS') registry = 'J_CREDIT'
+  else if (attributes.registry == 'JCS' || 'JPN') registry = 'J_CREDIT'
+  else if (attributes.registry == 'ACR') registry = 'AMERICAN_CARBON_REGISTRY'
   else if (attributes.registry == 'ECO') registry = 'ECO_REGISTRY'
 
   let project = loadOrCreateCarbonProject(registry, attributes.registry + '-' + attributes.project_id)

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -85,7 +85,7 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
 
   /** the last two charactes of a JCS or JPN project ID are a suffix id of
    * the vintage and do not relate to the project itself */
-  if (attributes.registry == 'JCS' || attributes.registry == 'JPN') {
+  if (attributes.registry === 'JCS' || attributes.registry === 'JPN') {
     projectID = attributes.project_id.slice(0, attributes.project_id.length - 2)
   } else {
     projectID = attributes.project_id
@@ -101,12 +101,10 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
 
   project.methodologies = attributes.methodology
   project.category = MethodologyCategories.getMethodologyCategory(project.methodologies)
-  project.country = attributes.country
-  project.category = attributes.project_type
   project.region = attributes.region
   project.methodologies = attributes.methodology
-  project.name = attributes.name
   project.save()
+  
   return carbonCredit
 }
 

--- a/polygon-digital-carbon/src/utils/Provenance.ts
+++ b/polygon-digital-carbon/src/utils/Provenance.ts
@@ -118,8 +118,10 @@ export function updateProvenanceForRetirement(creditId: Bytes): Bytes | null {
 
   if (project == null) return null
 
+  /** these J_CREDIT and ECO credits C3 tokens that have async retires.
+   * The tokens are transferred back to the contract and then retired from there */
   let id =
-    (project.registry == 'J_CREDIT' || project.registry == 'ECO')
+    project.registry == 'J_CREDIT' || project.registry == 'ECO'
       ? creditId.concat(Address.fromHexString(credit.tokenAddress.toHexString())).concatI32(credit.provenanceCount - 1)
       : creditId.concat(ZERO_ADDRESS).concatI32(credit.provenanceCount - 1)
   let record = ProvenanceRecord.load(id)

--- a/polygon-digital-carbon/src/utils/Provenance.ts
+++ b/polygon-digital-carbon/src/utils/Provenance.ts
@@ -5,6 +5,7 @@ import { loadOrCreateHolding } from './Holding'
 import { ZERO_BI } from '../../../lib/utils/Decimals'
 import { loadOrCreateToucanBatch } from './ToucanBatch'
 import { ZERO_ADDRESS } from '../../../lib/utils/Constants'
+import { CarbonProject } from '../../generated/schema'
 
 export function recordProvenance(
   hash: Bytes,
@@ -113,7 +114,14 @@ export function recordProvenance(
 
 export function updateProvenanceForRetirement(creditId: Bytes): Bytes | null {
   let credit = loadCarbonCredit(creditId)
-  let id = creditId.concat(ZERO_ADDRESS).concatI32(credit.provenanceCount - 1)
+  let project = CarbonProject.load(credit.project)
+
+  if (project == null) return null
+
+  let id =
+    project.registry == 'J_CREDIT'
+      ? creditId.concat(Address.fromHexString(credit.tokenAddress.toHexString())).concatI32(credit.provenanceCount - 1)
+      : creditId.concat(ZERO_ADDRESS).concatI32(credit.provenanceCount - 1)
   let record = ProvenanceRecord.load(id)
   if (record == null) {
     return null

--- a/polygon-digital-carbon/src/utils/Provenance.ts
+++ b/polygon-digital-carbon/src/utils/Provenance.ts
@@ -119,7 +119,7 @@ export function updateProvenanceForRetirement(creditId: Bytes): Bytes | null {
   if (project == null) return null
 
   let id =
-    project.registry == 'J_CREDIT'
+    (project.registry == 'J_CREDIT' || project.registry == 'ECO')
       ? creditId.concat(Address.fromHexString(credit.tokenAddress.toHexString())).concatI32(credit.provenanceCount - 1)
       : creditId.concat(ZERO_ADDRESS).concatI32(credit.provenanceCount - 1)
   let record = ProvenanceRecord.load(id)

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 0.0.8
 description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
@@ -224,6 +224,7 @@ dataSources:
       file: ./src/templates/C3ProjectTokenFactory.ts
       entities:
         - C3ProjectTokenFactory
+        - TokenURISafeguard
       abis:
         - name: C3ProjectTokenFactory
           file: ../lib/abis/C3ProjectTokenFactory.json
@@ -231,6 +232,8 @@ dataSources:
           file: ../lib/abis/C3ProjectToken.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
+        - name: C3OffsetNFT
+          file: ../lib/abis/C3OffsetNFT.json
       eventHandlers:
         - event: NewTokenProject(string,address)
           handler: handleNewC3T
@@ -238,6 +241,11 @@ dataSources:
           handler: handleStartAsyncToken
         - event: EndAsyncToken(address,address,address,uint256,string,string,uint256,uint256,bool,uint256)
           handler: handleEndAsyncToken
+      blockHandlers:
+        - handler: handleTokenURISafeguard
+          filter:
+            kind: polling
+            every: 75 # approx every 2.5 minutes
   - kind: ethereum/contract
     name: UBO
     network: {{network}}

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -234,6 +234,10 @@ dataSources:
       eventHandlers:
         - event: NewTokenProject(string,address)
           handler: handleNewC3T
+        - event: StartAsyncToken(address,address,address,uint256,string,string,uint256,uint256)
+          handler: handleStartAsyncToken
+        - event: EndAsyncToken(address,address,address,uint256,string,string,uint256,uint256,bool,uint256)
+          handler: handleEndAsyncToken
   - kind: ethereum/contract
     name: UBO
     network: {{network}}

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -9,13 +9,14 @@ graft:
   base: QmUTK4dB7CXVvN2XsX1temzZGcryQ59j8YKdQP5Z2AwzVZ
   block: 58282296
 dataSources:
+# # invalid block for mumbai start
   - kind: ethereum/contract
     name: ToucanFactory
-    network: matic
+    network: mumbai
     source:
       address: '0x2359677E513Bc83106268514c5B2De3C29C849ea'
       abi: ToucanCarbonOffsetsFactory
-      startBlock: 20078328
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -35,11 +36,11 @@ dataSources:
           handler: handleNewTCO2
   - kind: ethereum/contract
     name: ToucanCarbonOffsetBatch
-    network: matic
+    network: mumbai
     source:
       address: '0x8A4d7458dDe3023A3B24225D62087701A88b09DD'
       abi: ToucanCarbonOffsetBatches
-      startBlock: 20078307
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -59,11 +60,11 @@ dataSources:
           handler: handleBatchTransfer
   - kind: ethereum/contract
     name: BCT
-    network: matic
+    network: mumbai
     source:
-      address: '0x2F800Db0fdb5223b3C3f354886d907A671414A7F'
+      address: '0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5'
       abi: ToucanCarbonPool
-      startBlock: 20078351
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -87,11 +88,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NCT
-    network: matic
+    network: mumbai
     source:
       address: '0xD838290e877E0188a4A44700463419ED96c16107'
       abi: ToucanCarbonPool
-      startBlock: 24705011
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -116,11 +117,11 @@ dataSources:
   # Toucan cross chain bridges
   - kind: ethereum/contract
     name: ToucanCrossChainMessenger
-    network: matic
+    network: mumbai
     source:
       address: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf'
       abi: ToucanCrossChainMessenger
-      startBlock: 31390596
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -146,11 +147,11 @@ dataSources:
           handler: handleBridgeRequestSent_1_1_0
   - kind: ethereum/contract
     name: ToucanRegenBridge
-    network: matic
+    network: mumbai
     source:
       address: '0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC'
       abi: ToucanRegenBridge
-      startBlock: 40568139
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -170,11 +171,11 @@ dataSources:
           handler: handleToucanRegenIssue
   - kind: ethereum/contract
     name: MossCarbon
-    network: matic
+    network: mumbai
     source:
       address: '0xaa7dbd1598251f856c12f63557a4c4397c253cea'
       abi: ERC20
-      startBlock: 23193932
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -190,11 +191,11 @@ dataSources:
           handler: handleCreditTransfer
   - kind: ethereum/contract
     name: MossCarbonOffset
-    network: matic
+    network: mumbai
     source:
       address: '0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8'
       abi: CarbonChain
-      startBlock: 25259584
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -210,13 +211,14 @@ dataSources:
           handler: handleMossRetirement
         # - event: CarbonOffsetBatch((uint256,bytes32,uint256,uint256),uint256,bytes32,uint256)
         #   handler: handleMossRetirementToMainnet
+  # invalid block for mumbai end
   - kind: ethereum/contract
     name: C3ProjectTokenFactory
-    network: matic
+    network: mumbai
     source:
-      address: '0xa4c951B30952f5E2feFC8a92F4d3c7551925A63B'
+      address: '0x3bC4FF4787C0F7Cd83EFB424176f559A00cf28c3'
       abi: C3ProjectTokenFactory
-      startBlock: 25427652
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -236,11 +238,11 @@ dataSources:
           handler: handleNewC3T
   - kind: ethereum/contract
     name: UBO
-    network: matic
+    network: mumbai
     source:
-      address: '0x2B3eCb0991AF0498ECE9135bcD04013d7993110c'
+      address: '0x1C08ED3fF245dE937a6414C2C39E372f2640f5f8'
       abi: C3CarbonPool
-      startBlock: 25429110
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -262,11 +264,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NBO
-    network: matic
+    network: mumbai
     source:
-      address: '0x6BCa3B77C1909Ce1a4Ba1A20d1103bDe8d222E48'
+      address: '0x28D5158d45EC651133Fac4c858BeD65252Ed5b7b'
       abi: C3CarbonPool
-      startBlock: 25428966
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -288,11 +290,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: C3-Offset
-    network: matic
+    network: mumbai
     source:
       address: '0x7b364DFc0e085468aFDe869DF20036D80b8868e7'
       abi: C3OffsetNFT
-      startBlock: 27049043
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -306,13 +308,14 @@ dataSources:
       eventHandlers:
         - event: VCUOMinted(address,uint256)
           handler: handleVCUOMinted
+  # invalid block for mumbai end
   - kind: ethereum/contract
     name: ICRCarbonContractRegistry
-    network: matic
+    network: mumbai
     source:
-      address: '0x9f87988ff45e9b58ae30fa1685088460125a7d8a'
+      address: '0x825CcCB05D82fcD0381E523116A03b9301E91C61'
       abi: ICRCarbonContractRegistry
-      startBlock: 42035327
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -330,14 +333,15 @@ dataSources:
       eventHandlers:
         - event: ProjectCreated(indexed uint256,indexed address,string)
           handler: handleNewICC
+  # invalid block for mumbai start
   # Retirement aggregator
   - kind: ethereum/contract
     name: RetireToucanCarbon
-    network: matic
+    network: mumbai
     source:
       address: '0xCefb61aF5325C0c100cBd77eb4c9F51d17B189Ca'
       abi: RetireToucanCarbon
-      startBlock: 25476120
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -357,11 +361,11 @@ dataSources:
           handler: handleToucanRetired
   - kind: ethereum/contract
     name: RetireMossCarbon
-    network: matic
+    network: mumbai
     source:
       address: '0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5'
       abi: RetireMossCarbon
-      startBlock: 25476110
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -379,13 +383,14 @@ dataSources:
       eventHandlers:
         - event: MossRetired(indexed address,indexed address,string,string,indexed address,uint256)
           handler: handleMossRetired
+  # invalid block for mumbai end
   - kind: ethereum/contract
     name: RetireC3Carbon
-    network: matic
+    network: mumbai
     source:
-      address: '0x933AF8c652c696FB0969Eb85DDd111edb2b4E057'
+      address: '0x7803fd5A4f5cDB814b3DF3d5fEe1374734Ad90FF'
       abi: RetireC3Carbon
-      startBlock: 27175005
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -405,11 +410,11 @@ dataSources:
           handler: handleC3Retired
   - kind: ethereum/contract
     name: KlimaInfinity
-    network: matic
+    network: mumbai
     source:
-      address: '0x8cE54d9625371fb2a068986d32C85De8E6e995f8'
+      address: '0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8'
       abi: KlimaInfinity
-      startBlock: 36550000
+      startBlock: 47284985
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -429,31 +434,32 @@ dataSources:
           handler: handleCarbonRetired
         - event: CarbonRetired(uint8,indexed address,string,indexed address,string,string,indexed address,address,uint256,uint256)
           handler: handleCarbonRetiredWithTokenId
-  # Track KLIMA rebases for creating supply snapshot
-  - kind: ethereum/contract
-    name: sKlimaERC20V1
-    network: matic
-    source:
-      address: '0xb0C22d8D350C67420f06F48936654f567C73E8C8'
-      abi: sKlimaERC20V1
-      startBlock: 20190686
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities:
-        - sKlima
-      abis:
-        - name: sKlimaERC20V1
-          file: ../lib/abis/sKlimaERC20V1.json
-      eventHandlers:
-        - event: LogRebase(indexed uint256,uint256,uint256)
-          handler: handleRebase
-      file: ./src/sKlimaV1.ts
+  #   # Track KLIMA rebases for creating supply snapshot
+  #   - kind: ethereum/contract
+  #     name: sKlimaERC20V1
+  #     network: mumbai
+  #     source:
+  #       address: '0xb0C22d8D350C67420f06F48936654f567C73E8C8'
+  #       abi: sKlimaERC20V1
+  #       startBlock: 42944858
+  #     mapping:
+  #       kind: ethereum/events
+  #       apiVersion: 0.0.7
+  #       language: wasm/assemblyscript
+  #       entities:
+  #         - sKlima
+  #       abis:
+  #         - name: sKlimaERC20V1
+  #           file: ../lib/abis/sKlimaERC20V1.json
+  #       eventHandlers:
+  #         - event: LogRebase(indexed uint256,uint256,uint256)
+  #           handler: handleRebase
+  #       file: ./src/sKlimaV1.ts
 templates:
+  # invalid block for mumbai start
   - name: ToucanCarbonOffsets
     kind: ethereum/contract
-    network: matic
+    network: mumbai
     source:
       abi: ToucanCarbonOffsets
     mapping:
@@ -477,7 +483,7 @@ templates:
       file: ./src/TransferHandler.ts
   - name: C3ProjectToken
     kind: ethereum/contract
-    network: matic
+    network: mumbai
     source:
       abi: C3ProjectToken
     mapping:
@@ -486,18 +492,26 @@ templates:
       language: wasm/assemblyscript
       entities:
         - C3ProjectToken
+        - C3OffsetRequest
       abis:
         - name: C3ProjectToken
           file: ../lib/abis/C3ProjectToken.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
+        - name: KlimaCarbonRetirements
+          file: ../lib/abis/KlimaCarbonRetirements.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleCreditTransfer
+        - event: StartAsyncToken(address,address,uint256,string,string,uint256,uint256)
+          handler: handleStartAsyncToken
+        - event: EndAsyncToken(address,address,uint256,string,string,uint256,bool,uint256,uint256)
+          handler: handleEndAsyncToken
       file: ./src/TransferHandler.ts
+  #  invalid block for mumbai end
   - name: ICRProjectToken
     kind: ethereum/contract
-    network: matic
+    network: mumbai
     source:
       abi: ICRProjectToken
     mapping:

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -9,7 +9,7 @@ graft:
   base: QmUTK4dB7CXVvN2XsX1temzZGcryQ59j8YKdQP5Z2AwzVZ
   block: 58282296
 dataSources:
-# # invalid block for mumbai start
+  # # invalid block for mumbai start
   - kind: ethereum/contract
     name: ToucanFactory
     network: mumbai
@@ -216,7 +216,7 @@ dataSources:
     name: C3ProjectTokenFactory
     network: mumbai
     source:
-      address: '0x3bC4FF4787C0F7Cd83EFB424176f559A00cf28c3'
+      address: '0x3bc4ff4787c0f7cd83efb424176f559a00cf28c3'
       abi: C3ProjectTokenFactory
       startBlock: 47284985
     mapping:
@@ -240,7 +240,7 @@ dataSources:
     name: UBO
     network: mumbai
     source:
-      address: '0x1C08ED3fF245dE937a6414C2C39E372f2640f5f8'
+      address: '0x1c08ed3ff245de937a6414c2c39e372f2640f5f8'
       abi: C3CarbonPool
       startBlock: 47284985
     mapping:
@@ -266,7 +266,7 @@ dataSources:
     name: NBO
     network: mumbai
     source:
-      address: '0x28D5158d45EC651133Fac4c858BeD65252Ed5b7b'
+      address: '0x28d5158d45ec651133fac4c858bed65252ed5b7b'
       abi: C3CarbonPool
       startBlock: 47284985
     mapping:
@@ -292,7 +292,7 @@ dataSources:
     name: C3-Offset
     network: mumbai
     source:
-      address: '0xF977c9328ED849d6CeE131A0B268028ED3404cb6'
+      address: '0xddafb3df0e464cd3252d50da405909185a7e1fbf'
       abi: C3OffsetNFT
       startBlock: 47284985
     mapping:
@@ -313,7 +313,7 @@ dataSources:
     name: ICRCarbonContractRegistry
     network: mumbai
     source:
-      address: '0x825CcCB05D82fcD0381E523116A03b9301E91C61'
+      address: '0x825cccb05d82fcd0381e523116a03b9301e91c61'
       abi: ICRCarbonContractRegistry
       startBlock: 47284985
     mapping:
@@ -339,7 +339,7 @@ dataSources:
     name: RetireToucanCarbon
     network: mumbai
     source:
-      address: '0xCefb61aF5325C0c100cBd77eb4c9F51d17B189Ca'
+      address: '0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca'
       abi: RetireToucanCarbon
       startBlock: 47284985
     mapping:
@@ -388,7 +388,7 @@ dataSources:
     name: RetireC3Carbon
     network: mumbai
     source:
-      address: '0x7803fd5A4f5cDB814b3DF3d5fEe1374734Ad90FF'
+      address: '0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff'
       abi: RetireC3Carbon
       startBlock: 47284985
     mapping:

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.4
+specVersion: 0.0.8
 description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
@@ -11,11 +11,11 @@ graft:
 dataSources:
   - kind: ethereum/contract
     name: ToucanFactory
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8'
+      address: '0x2359677E513Bc83106268514c5B2De3C29C849ea'
       abi: ToucanCarbonOffsetsFactory
-      startBlock: 7667754
+      startBlock: 20078328
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -35,11 +35,11 @@ dataSources:
           handler: handleNewTCO2
   - kind: ethereum/contract
     name: ToucanCarbonOffsetBatch
-    network: polygon-amoy
+    network: matic
     source:
       address: '0x8A4d7458dDe3023A3B24225D62087701A88b09DD'
       abi: ToucanCarbonOffsetBatches
-      startBlock: 7667754
+      startBlock: 20078307
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -59,11 +59,11 @@ dataSources:
           handler: handleBatchTransfer
   - kind: ethereum/contract
     name: BCT
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5'
+      address: '0x2F800Db0fdb5223b3C3f354886d907A671414A7F'
       abi: ToucanCarbonPool
-      startBlock: 7667754
+      startBlock: 20078351
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -87,11 +87,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NCT
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xD838290e877E0188a4A44700463419ED96c16107'
       abi: ToucanCarbonPool
-      startBlock: 7667754
+      startBlock: 24705011
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -116,11 +116,11 @@ dataSources:
   # Toucan cross chain bridges
   - kind: ethereum/contract
     name: ToucanCrossChainMessenger
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf'
       abi: ToucanCrossChainMessenger
-      startBlock: 7667754
+      startBlock: 31390596
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -146,11 +146,11 @@ dataSources:
           handler: handleBridgeRequestSent_1_1_0
   - kind: ethereum/contract
     name: ToucanRegenBridge
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC'
       abi: ToucanRegenBridge
-      startBlock: 7667754
+      startBlock: 40568139
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -170,7 +170,7 @@ dataSources:
           handler: handleToucanRegenIssue
   - kind: ethereum/contract
     name: MossCarbon
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xaa7dbd1598251f856c12f63557a4c4397c253cea'
       abi: ERC20
@@ -190,11 +190,11 @@ dataSources:
           handler: handleCreditTransfer
   - kind: ethereum/contract
     name: MossCarbonOffset
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8'
       abi: CarbonChain
-      startBlock: 7667754
+      startBlock: 25259584
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -212,11 +212,11 @@ dataSources:
         #   handler: handleMossRetirementToMainnet
   - kind: ethereum/contract
     name: C3ProjectTokenFactory
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0xd0CAE7819FA604ADB8C5c7A2685E6324b9c5417C'
+      address: '0xa4c951B30952f5E2feFC8a92F4d3c7551925A63B'
       abi: C3ProjectTokenFactory
-      startBlock: 6827036
+      startBlock: 25427652
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -224,6 +224,7 @@ dataSources:
       file: ./src/templates/C3ProjectTokenFactory.ts
       entities:
         - C3ProjectTokenFactory
+        - TokenURISafeguard
       abis:
         - name: C3ProjectTokenFactory
           file: ../lib/abis/C3ProjectTokenFactory.json
@@ -231,6 +232,8 @@ dataSources:
           file: ../lib/abis/C3ProjectToken.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
+        - name: C3OffsetNFT
+          file: ../lib/abis/C3OffsetNFT.json
       eventHandlers:
         - event: NewTokenProject(string,address)
           handler: handleNewC3T
@@ -238,13 +241,18 @@ dataSources:
           handler: handleStartAsyncToken
         - event: EndAsyncToken(address,address,address,uint256,string,string,uint256,uint256,bool,uint256)
           handler: handleEndAsyncToken
+      blockHandlers:
+        - handler: handleTokenURISafeguard
+          filter:
+            kind: polling
+            every: 75 # approx every 2.5 minutes
   - kind: ethereum/contract
     name: UBO
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0xd9cf88c9993AEf429160c7D725f9aFB4E25e2733'
+      address: '0x2B3eCb0991AF0498ECE9135bcD04013d7993110c'
       abi: C3CarbonPool
-      startBlock: 6827291
+      startBlock: 25429110
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -266,11 +274,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NBO
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0x71Fb8a17b8DF0D6e3f14F0A955eC7da8140f640A'
+      address: '0x6BCa3B77C1909Ce1a4Ba1A20d1103bDe8d222E48'
       abi: C3CarbonPool
-      startBlock: 6827303
+      startBlock: 25428966
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -292,11 +300,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: C3-Offset
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0x282f92B498744ae357403e0e692646104fCB1dfc'
+      address: '0x7b364DFc0e085468aFDe869DF20036D80b8868e7'
       abi: C3OffsetNFT
-      startBlock: 6827054
+      startBlock: 27049043
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -312,11 +320,11 @@ dataSources:
           handler: handleVCUOMinted
   - kind: ethereum/contract
     name: ICRCarbonContractRegistry
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0x825cccb05d82fcd0381e523116a03b9301e91c61'
+      address: '0x9f87988ff45e9b58ae30fa1685088460125a7d8a'
       abi: ICRCarbonContractRegistry
-      startBlock: 7667754
+      startBlock: 42035327
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -337,11 +345,11 @@ dataSources:
   # Retirement aggregator
   - kind: ethereum/contract
     name: RetireToucanCarbon
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca'
+      address: '0xCefb61aF5325C0c100cBd77eb4c9F51d17B189Ca'
       abi: RetireToucanCarbon
-      startBlock: 7667754
+      startBlock: 25476120
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -361,11 +369,11 @@ dataSources:
           handler: handleToucanRetired
   - kind: ethereum/contract
     name: RetireMossCarbon
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5'
       abi: RetireMossCarbon
-      startBlock: 7667754
+      startBlock: 25476110
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -385,11 +393,11 @@ dataSources:
           handler: handleMossRetired
   - kind: ethereum/contract
     name: RetireC3Carbon
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0x53AC0d9F5985551C1f0ca98665d870365D1c6Ead'
+      address: '0x933AF8c652c696FB0969Eb85DDd111edb2b4E057'
       abi: RetireC3Carbon
-      startBlock: 7161008
+      startBlock: 27175005
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -409,11 +417,11 @@ dataSources:
           handler: handleC3Retired
   - kind: ethereum/contract
     name: KlimaInfinity
-    network: polygon-amoy
+    network: matic
     source:
-      address: '0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54'
+      address: '0x8cE54d9625371fb2a068986d32C85De8E6e995f8'
       abi: KlimaInfinity
-      startBlock: 7161009
+      startBlock: 36550000
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -436,7 +444,7 @@ dataSources:
   # Track KLIMA rebases for creating supply snapshot
   - kind: ethereum/contract
     name: sKlimaERC20V1
-    network: polygon-amoy
+    network: matic
     source:
       address: '0xb0C22d8D350C67420f06F48936654f567C73E8C8'
       abi: sKlimaERC20V1
@@ -457,7 +465,7 @@ dataSources:
 templates:
   - name: ToucanCarbonOffsets
     kind: ethereum/contract
-    network: polygon-amoy
+    network: matic
     source:
       abi: ToucanCarbonOffsets
     mapping:
@@ -481,7 +489,7 @@ templates:
       file: ./src/TransferHandler.ts
   - name: C3ProjectToken
     kind: ethereum/contract
-    network: polygon-amoy
+    network: matic
     source:
       abi: C3ProjectToken
     mapping:
@@ -501,7 +509,7 @@ templates:
       file: ./src/TransferHandler.ts
   - name: ICRProjectToken
     kind: ethereum/contract
-    network: polygon-amoy
+    network: matic
     source:
       abi: ICRProjectToken
     mapping:

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -9,14 +9,13 @@ graft:
   base: QmUTK4dB7CXVvN2XsX1temzZGcryQ59j8YKdQP5Z2AwzVZ
   block: 58282296
 dataSources:
-  # # invalid block for mumbai start
   - kind: ethereum/contract
     name: ToucanFactory
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0x2359677E513Bc83106268514c5B2De3C29C849ea'
+      address: '0xdDd96D43b0B2Ca179DCefA58e71798d0ce56c9c8'
       abi: ToucanCarbonOffsetsFactory
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -36,11 +35,11 @@ dataSources:
           handler: handleNewTCO2
   - kind: ethereum/contract
     name: ToucanCarbonOffsetBatch
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0x8A4d7458dDe3023A3B24225D62087701A88b09DD'
       abi: ToucanCarbonOffsetBatches
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -60,11 +59,11 @@ dataSources:
           handler: handleBatchTransfer
   - kind: ethereum/contract
     name: BCT
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0x8f8b7D5d12c1fC37f20a89Bf4Dfe1E787Da529B5'
       abi: ToucanCarbonPool
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -88,11 +87,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NCT
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xD838290e877E0188a4A44700463419ED96c16107'
       abi: ToucanCarbonPool
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -117,11 +116,11 @@ dataSources:
   # Toucan cross chain bridges
   - kind: ethereum/contract
     name: ToucanCrossChainMessenger
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xABaC3D6b281Bbe0Fc0F67b26247cB27994eaAcaf'
       abi: ToucanCrossChainMessenger
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -147,11 +146,11 @@ dataSources:
           handler: handleBridgeRequestSent_1_1_0
   - kind: ethereum/contract
     name: ToucanRegenBridge
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xdC1Dfa22824Af4e423a558bbb6C53a31c3c11DCC'
       abi: ToucanRegenBridge
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -171,11 +170,11 @@ dataSources:
           handler: handleToucanRegenIssue
   - kind: ethereum/contract
     name: MossCarbon
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xaa7dbd1598251f856c12f63557a4c4397c253cea'
       abi: ERC20
-      startBlock: 47284985
+      startBlock: 23193932
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -191,11 +190,11 @@ dataSources:
           handler: handleCreditTransfer
   - kind: ethereum/contract
     name: MossCarbonOffset
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xeDAEFCf60e12Bd331c092341D5b3d8901C1c05A8'
       abi: CarbonChain
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -211,14 +210,13 @@ dataSources:
           handler: handleMossRetirement
         # - event: CarbonOffsetBatch((uint256,bytes32,uint256,uint256),uint256,bytes32,uint256)
         #   handler: handleMossRetirementToMainnet
-  # invalid block for mumbai end
   - kind: ethereum/contract
     name: C3ProjectTokenFactory
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0x3bc4ff4787c0f7cd83efb424176f559a00cf28c3'
+      address: '0xd0CAE7819FA604ADB8C5c7A2685E6324b9c5417C'
       abi: C3ProjectTokenFactory
-      startBlock: 47284985
+      startBlock: 6827036
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -236,13 +234,17 @@ dataSources:
       eventHandlers:
         - event: NewTokenProject(string,address)
           handler: handleNewC3T
+        - event: StartAsyncToken(address,address,address,uint256,string,string,uint256,uint256)
+          handler: handleStartAsyncToken
+        - event: EndAsyncToken(address,address,address,uint256,string,string,uint256,uint256,bool,uint256)
+          handler: handleEndAsyncToken
   - kind: ethereum/contract
     name: UBO
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0x1c08ed3ff245de937a6414c2c39e372f2640f5f8'
+      address: '0xd9cf88c9993AEf429160c7D725f9aFB4E25e2733'
       abi: C3CarbonPool
-      startBlock: 47284985
+      startBlock: 6827291
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -264,11 +266,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: NBO
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0x28d5158d45ec651133fac4c858bed65252ed5b7b'
+      address: '0x71Fb8a17b8DF0D6e3f14F0A955eC7da8140f640A'
       abi: C3CarbonPool
-      startBlock: 47284985
+      startBlock: 6827303
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -290,11 +292,11 @@ dataSources:
           handler: handleTransfer
   - kind: ethereum/contract
     name: C3-Offset
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0xddafb3df0e464cd3252d50da405909185a7e1fbf'
+      address: '0x282f92B498744ae357403e0e692646104fCB1dfc'
       abi: C3OffsetNFT
-      startBlock: 47284985
+      startBlock: 6827054
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -308,14 +310,13 @@ dataSources:
       eventHandlers:
         - event: VCUOMinted(address,uint256)
           handler: handleVCUOMinted
-  # invalid block for mumbai end
   - kind: ethereum/contract
     name: ICRCarbonContractRegistry
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0x825cccb05d82fcd0381e523116a03b9301e91c61'
       abi: ICRCarbonContractRegistry
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -333,15 +334,14 @@ dataSources:
       eventHandlers:
         - event: ProjectCreated(indexed uint256,indexed address,string)
           handler: handleNewICC
-  # invalid block for mumbai start
   # Retirement aggregator
   - kind: ethereum/contract
     name: RetireToucanCarbon
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xcefb61af5325c0c100cbd77eb4c9f51d17b189ca'
       abi: RetireToucanCarbon
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -361,11 +361,11 @@ dataSources:
           handler: handleToucanRetired
   - kind: ethereum/contract
     name: RetireMossCarbon
-    network: mumbai
+    network: polygon-amoy
     source:
       address: '0xa35f62dbdb93e4B772784E89B7B35736A4aeaCc5'
       abi: RetireMossCarbon
-      startBlock: 47284985
+      startBlock: 7667754
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -383,14 +383,13 @@ dataSources:
       eventHandlers:
         - event: MossRetired(indexed address,indexed address,string,string,indexed address,uint256)
           handler: handleMossRetired
-  # invalid block for mumbai end
   - kind: ethereum/contract
     name: RetireC3Carbon
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0x7803fd5a4f5cdb814b3df3d5fee1374734ad90ff'
+      address: '0x53AC0d9F5985551C1f0ca98665d870365D1c6Ead'
       abi: RetireC3Carbon
-      startBlock: 47284985
+      startBlock: 7161008
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -410,11 +409,11 @@ dataSources:
           handler: handleC3Retired
   - kind: ethereum/contract
     name: KlimaInfinity
-    network: mumbai
+    network: polygon-amoy
     source:
-      address: '0x62d3897089C93A0fa2B0746A6975Ec4693c13cb8'
+      address: '0x41e07f12f4E4297B98c2E2e1E93EE2518a07CD54'
       abi: KlimaInfinity
-      startBlock: 47284985
+      startBlock: 7161009
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -434,32 +433,31 @@ dataSources:
           handler: handleCarbonRetired
         - event: CarbonRetired(uint8,indexed address,string,indexed address,string,string,indexed address,address,uint256,uint256)
           handler: handleCarbonRetiredWithTokenId
-  #   # Track KLIMA rebases for creating supply snapshot
-  #   - kind: ethereum/contract
-  #     name: sKlimaERC20V1
-  #     network: mumbai
-  #     source:
-  #       address: '0xb0C22d8D350C67420f06F48936654f567C73E8C8'
-  #       abi: sKlimaERC20V1
-  #       startBlock: 42944858
-  #     mapping:
-  #       kind: ethereum/events
-  #       apiVersion: 0.0.7
-  #       language: wasm/assemblyscript
-  #       entities:
-  #         - sKlima
-  #       abis:
-  #         - name: sKlimaERC20V1
-  #           file: ../lib/abis/sKlimaERC20V1.json
-  #       eventHandlers:
-  #         - event: LogRebase(indexed uint256,uint256,uint256)
-  #           handler: handleRebase
-  #       file: ./src/sKlimaV1.ts
+  # Track KLIMA rebases for creating supply snapshot
+  - kind: ethereum/contract
+    name: sKlimaERC20V1
+    network: polygon-amoy
+    source:
+      address: '0xb0C22d8D350C67420f06F48936654f567C73E8C8'
+      abi: sKlimaERC20V1
+      startBlock: 20190686
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - sKlima
+      abis:
+        - name: sKlimaERC20V1
+          file: ../lib/abis/sKlimaERC20V1.json
+      eventHandlers:
+        - event: LogRebase(indexed uint256,uint256,uint256)
+          handler: handleRebase
+      file: ./src/sKlimaV1.ts
 templates:
-  # invalid block for mumbai start
   - name: ToucanCarbonOffsets
     kind: ethereum/contract
-    network: mumbai
+    network: polygon-amoy
     source:
       abi: ToucanCarbonOffsets
     mapping:
@@ -483,7 +481,7 @@ templates:
       file: ./src/TransferHandler.ts
   - name: C3ProjectToken
     kind: ethereum/contract
-    network: mumbai
+    network: polygon-amoy
     source:
       abi: C3ProjectToken
     mapping:
@@ -492,26 +490,18 @@ templates:
       language: wasm/assemblyscript
       entities:
         - C3ProjectToken
-        - C3OffsetRequest
       abis:
         - name: C3ProjectToken
           file: ../lib/abis/C3ProjectToken.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
-        - name: KlimaCarbonRetirements
-          file: ../lib/abis/KlimaCarbonRetirements.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleCreditTransfer
-        - event: StartAsyncToken(address,address,uint256,string,string,uint256,uint256)
-          handler: handleStartAsyncToken
-        - event: EndAsyncToken(address,address,uint256,string,string,uint256,bool,uint256,uint256)
-          handler: handleEndAsyncToken
       file: ./src/TransferHandler.ts
-  #  invalid block for mumbai end
   - name: ICRProjectToken
     kind: ethereum/contract
-    network: mumbai
+    network: polygon-amoy
     source:
       abi: ICRProjectToken
     mapping:

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -292,7 +292,7 @@ dataSources:
     name: C3-Offset
     network: mumbai
     source:
-      address: '0x7b364DFc0e085468aFDe869DF20036D80b8868e7'
+      address: '0xF977c9328ED849d6CeE131A0B268028ED3404cb6'
       abi: C3OffsetNFT
       startBlock: 47284985
     mapping:

--- a/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
+++ b/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
@@ -1,0 +1,6 @@
+import { AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT, KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
+import { Address } from '@graphprotocol/graph-ts'
+
+export function getRetirementsContractAddress(network: string): Address {
+  return network == 'matic' ? KLIMA_CARBON_RETIREMENTS_CONTRACT : AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT
+}

--- a/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
+++ b/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
@@ -1,6 +1,10 @@
 import { AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT, KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
-import { Address } from '@graphprotocol/graph-ts'
+import { Address, Bytes, ByteArray, BigInt } from '@graphprotocol/graph-ts'
 
 export function getRetirementsContractAddress(network: string): Address {
   return network == 'matic' ? KLIMA_CARBON_RETIREMENTS_CONTRACT : AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT
+}
+
+export function getC3OffsetRequestId(fromToken: Address, beneficiaryAddress: Address, index: BigInt): string {
+  return fromToken.toHexString() + '-' + beneficiaryAddress.toHexString() + '-' + index.toString()
 }


### PR DESCRIPTION
As there are two transactions hashes, it should make sense to store the finalization transaction hash as that is the hash that confirms retirement.

Where VCUOMinted would normally save the retire, it should not save the retire for async credits, J-credit or Eco credits, as these retires are already saved from the start async token event.

In EndAsyncToken, the retirement cannot be loaded from the sender address, as the txn is initiated from a c3 wallet. The event provides `account` which is the account that initiated the first txn, which is used to create the correct retireId.

The tokenURI needed for c3 credits isn't always at the time of retirement. If it's not it's stored in a separate entity and blockHandler polls for tokenURIs for entities missing tokenURIs ~2mins.