### PR TITLE
[Carbonmark] Add tokenized `ECO_REGISTRY` and `J_CREDIT` projects to marketplace

### DIFF
--- a/carbonmark/src/Projects.ts
+++ b/carbonmark/src/Projects.ts
@@ -10275,4 +10275,37 @@ export const PROJECT_INFO: ProjectInfo[] = [
     '52',
     true
   ),
+  new ProjectInfo(
+    '0x5557cf0e9f4c47b1e536aac2ac4bd2c50f9090bb',
+    'JCS-19011',
+    '2031',
+    'Kyushu/Okinawa',
+    'EN-R-002 Ver. 1.0',
+    'Renewable Energy',
+    'Japan',
+    '0',
+    false
+  ),
+  new ProjectInfo(
+    '0x4b69a69a80048e321da1d751f0f9dc39b5d63454',
+    'ECO-22',
+    '2018',
+    'Choco',
+    'PROTOCOL CVCC 3.1',
+    'Carbon offsets',
+    'Choco',
+    '0',
+    false
+  ),
+  new ProjectInfo(
+    '0xa8853ffc5a0aeab7d31631a4b87cb12c0b289c6c',
+    'ECO-114',
+    '2022',
+    'Choco',
+    'PROTOCOL CVCC 3.1',
+    'Carbon offsets',
+    'Worldwide',
+    '0',
+    false
+  ),
 ]

--- a/carbonmark/src/Projects.ts
+++ b/carbonmark/src/Projects.ts
@@ -10301,7 +10301,7 @@ export const PROJECT_INFO: ProjectInfo[] = [
     '0xa8853ffc5a0aeab7d31631a4b87cb12c0b289c6c',
     'ECO-114',
     '2022',
-    'Choco',
+    'Worldwide',
     'PROTOCOL CVCC 3.1',
     'Carbon offsets',
     'Worldwide',


### PR DESCRIPTION
This PR adds currently minted ECO and J credit projects to the marketplace.

Digital carbon doesn't need additional info in lib for c3 projects as c3 includes all of this info onchain with getProjectInfo() on the token contract.