### PR TITLE
pdc/add-tokenAddress-to-Token

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -81,8 +81,10 @@ type ProvenanceRecord @entity {
 }
 
 type Token @entity {
-  "Ethereum contract address"
+  "Ethereum contract address. for ERC1155s id address.concat(tokenId)"
   id: Bytes!
+
+  tokenAddress: Bytes!
 
   "Name of the token"
   name: String!

--- a/polygon-digital-carbon/src/utils/Token.ts
+++ b/polygon-digital-carbon/src/utils/Token.ts
@@ -12,7 +12,8 @@ export function createTokenWithCall(tokenAddress: Address): void {
   token = new Token(tokenAddress)
 
   let tokenContract = ERC20.bind(tokenAddress)
-
+  
+  token.tokenAddress = tokenAddress
   token.name = tokenContract.name()
   token.symbol = tokenContract.symbol()
   token.decimals = tokenContract.decimals()
@@ -61,7 +62,7 @@ export function createICRTokenWithCall(tokenAddress: Address, tokenId: BigInt): 
       serializationParts[serializationParts.length - 1].toString()
 
     token.name = `ICR: ${symbol}`
-
+    token.tokenAddress = tokenAddress
     token.symbol = symbol
     token.decimals = 18
     token.tokenId = tokenId
@@ -90,6 +91,7 @@ export function loadOrCreateToken(tokenAddress: Address): Token {
     if (decimalCall.reverted) token.decimals = 18 // Default to 18 decimals
     else token.decimals = decimalCall.value
 
+    token.tokenAddress = tokenAddress
     token.latestPriceUSD = tokenAddress == USDC_ERC20_CONTRACT ? BigDecimal.fromString('1') : ZERO_BD
     token.latestPriceUSDUpdated = ZERO_BI
     token.latestPricePerKLIMA = ZERO_BD


### PR DESCRIPTION
For 1155s the `token.id` isn't reliable with to retrieve the tokenAddress without a util as the 1155 token id is concatenated with the tokenId. 

This PR adds a separate field, `tokenAddress`. It will be redundant for ERC20s but will allow clean up utils and removing conditional logic in the api.

Test deployment: https://api.studio.thegraph.com/query/28985/testing-ground/version/latest