### PR TITLE
Use `Bytes` for C3RetireRequest `id`

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -387,7 +387,7 @@ type ToucanBatch @entity {
 
 type C3RetireRequest @entity {
   "Request ID"
-  id: ID!
+  id: Bytes!
   index: BigInt!
   c3OffsetNftIndex: BigInt
   status: BridgeStatus!

--- a/polygon-digital-carbon/src/templates/C3ProjectTokenFactory.ts
+++ b/polygon-digital-carbon/src/templates/C3ProjectTokenFactory.ts
@@ -9,7 +9,7 @@ import { createTokenWithCall } from '../utils/Token'
 import { ZERO_BI } from '../../../lib/utils/Decimals'
 import { saveStartAsyncToken, completeC3RetireRequest } from '../RetirementHandler'
 import { C3_VERIFIED_CARBON_UNITS_OFFSET } from '../../../lib/utils/Constants'
-import { BigInt, ethereum, log } from '@graphprotocol/graph-ts'
+import { BigInt, Bytes, ethereum, log } from '@graphprotocol/graph-ts'
 import { TokenURISafeguard } from '../../generated/schema'
 import { C3OffsetNFT } from '../../generated/C3-Offset/C3OffsetNFT'
 import { loadC3RetireRequest } from '../utils/C3'
@@ -51,13 +51,13 @@ export function handleTokenURISafeguard(block: ethereum.Block): void {
 
   let c3OffsetNftContract = C3OffsetNFT.bind(C3_VERIFIED_CARBON_UNITS_OFFSET)
 
-  let updatedRequestArray: string[] = []
+  let updatedRequestArray: Bytes[] = []
 
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]
     let request = loadC3RetireRequest(requestId)
     if (request == null) {
-      log.error('handleURIBlockSafeguard request is null {}', [requestId])
+      log.error('handleURIBlockSafeguard request is null {}', [requestId.toHexString()])
       continue
     }
     let c3OffsetNftIndex = request.c3OffsetNftIndex

--- a/polygon-digital-carbon/src/utils/C3.ts
+++ b/polygon-digital-carbon/src/utils/C3.ts
@@ -1,9 +1,9 @@
-import { BigInt } from '@graphprotocol/graph-ts'
+import { BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { C3RetireRequest } from '../../generated/schema'
 import { BridgeStatus } from '../../utils/enums'
 
-export function loadOrCreateC3RetireRequest(requestId: string):C3RetireRequest {
-  let request =C3RetireRequest.load(requestId)
+export function loadOrCreateC3RetireRequest(requestId: Bytes): C3RetireRequest {
+  let request = C3RetireRequest.load(requestId)
 
   if (request == null) {
     request = new C3RetireRequest(requestId)
@@ -17,7 +17,7 @@ export function loadOrCreateC3RetireRequest(requestId: string):C3RetireRequest {
   return request
 }
 
-export function loadC3RetireRequest(requestId: string):C3RetireRequest | null {
-  let request =C3RetireRequest.load(requestId)
+export function loadC3RetireRequest(requestId: Bytes): C3RetireRequest | null {
+  let request = C3RetireRequest.load(requestId)
   return request
 }

--- a/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
+++ b/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
@@ -1,10 +1,10 @@
 import { AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT, KLIMA_CARBON_RETIREMENTS_CONTRACT } from '../../lib/utils/Constants'
-import { Address, BigInt } from '@graphprotocol/graph-ts'
+import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
 
 export function getRetirementsContractAddress(network: string): Address {
   return network == 'matic' ? KLIMA_CARBON_RETIREMENTS_CONTRACT : AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT
 }
 
-export function getC3RetireRequestId(fromToken: Address, index: BigInt): string {
-  return fromToken.toHexString() + '-' + index.toString()
+export function getC3RetireRequestId(fromToken: Address, index: BigInt): Bytes {
+  return fromToken.concatI32(index.toI32())
 }


### PR DESCRIPTION
Use `Bytes` for the C3RetireRequest id instead of ID/string to improve performance and sync speed

test deployment (still syncing): https://api.studio.thegraph.com/query/28985/testing-ground/c3BytesId