### PR TITLE
Handle `VCUOMetaDataUpdated` for C3 tokenURIs

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -409,7 +409,7 @@ type C3RetireRequest @entity {
   "Request ID"
   id: ID!
   index: BigInt!
-  c3OffsetNftIndex: BigInt
+  c3OffsetNftIndex: BigInt!
   status: BridgeStatus!
   retire: Retire
   provenance: ProvenanceRecord

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -337,8 +337,9 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           safeguard.requestsWithoutURI = requestsArray
           safeguard.save()
           log.error('Retrieved tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
+        } else {
+          request.tokenURI = tokenURI
         }
-        request.tokenURI = tokenURI
       }
 
       request.status = BridgeStatus.FINALIZED
@@ -357,8 +358,6 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
   let requestsArray = safeguard.requestsWithoutURI
   if (requestsArray.length == 0) return
 
-  let updatedRequestArray: string[] = []
-
   // target the request with the index that matches the event.params.tokenId
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]
@@ -367,22 +366,10 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
       log.error('handleURIBlockSafeguard request is null {}', [requestId])
       continue
     }
-    log.info('fixt request {}', [requestId])
-    log.info('fixt1 event.params.url {}', [event.params.url])
-    log.info('fixt2 event.params.tokenId {}', [event.params.tokenId.toString()])
-    log.error('request.c3OffsetNftIndex is null {}', [request.c3OffsetNftIndex.toString()])
 
     if (request.c3OffsetNftIndex == event.params.tokenId) {
       request.tokenURI = event.params.url
       request.save()
     }
-
-    // remove request from safeguard if tokenURI is found
-    if (request.tokenURI == null || request.tokenURI == '') {
-      updatedRequestArray.push(requestId)
-    }
   }
-
-  safeguard.requestsWithoutURI = updatedRequestArray
-  safeguard.save()
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -317,9 +317,10 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
     if (request.status == BridgeStatus.REQUESTED) {
       let c3OffsetNftContract = C3OffsetNFT.bind(C3_VERIFIED_CARBON_UNITS_OFFSET)
 
+      request.c3OffsetNftIndex = event.params.nftIndex
+
       let tokenURICall = c3OffsetNftContract.try_tokenURI(event.params.nftIndex)
 
-      request.c3OffsetNftIndex = event.params.nftIndex
       if (tokenURICall.reverted) {
         log.error('tokenURI call reverted for NFT index {}', [event.params.nftIndex.toString()])
       } else {
@@ -358,7 +359,7 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
 
   let updatedRequestArray: string[] = []
 
-  // target the request with the index that matches the event.index
+  // target the request with the index that matches the event.params.tokenId
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]
     let request = loadC3RetireRequest(requestId)
@@ -366,7 +367,12 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
       log.error('handleURIBlockSafeguard request is null {}', [requestId])
       continue
     }
-    if (request.c3OffsetNftIndex === event.params.tokenId) {
+    log.info('fixt request {}', [requestId])
+    log.info('fixt1 event.params.url {}', [event.params.url])
+    log.info('fixt2 event.params.tokenId {}', [event.params.tokenId.toString()])
+    log.error('request.c3OffsetNftIndex is null {}', [request.c3OffsetNftIndex.toString()])
+
+    if (request.c3OffsetNftIndex == event.params.tokenId) {
       request.tokenURI = event.params.url
       request.save()
     }

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.8
+specVersion: 0.0.4
 description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
@@ -288,11 +288,6 @@ dataSources:
           handler: handleStartAsyncToken
         - event: EndAsyncToken(address,address,address,uint256,string,string,uint256,uint256,bool,uint256)
           handler: handleEndAsyncToken
-      blockHandlers:
-        - handler: handleTokenURISafeguard
-          filter:
-            kind: polling
-            every: 75 # approx every 2.5 minutes
   - kind: ethereum/contract
     name: UBO
     network: {{network}}
@@ -365,6 +360,8 @@ dataSources:
       eventHandlers:
         - event: VCUOMinted(address,uint256)
           handler: handleVCUOMinted
+        - event: VCUOMetaDataUpdated(uint256,string)
+          handler: handleVCUOMetaDataUpdated
   - kind: ethereum/contract
     name: ICRCarbonContractRegistry
     network: {{network}}

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.8
+specVersion: 0.0.4
 description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
@@ -288,11 +288,6 @@ dataSources:
           handler: handleStartAsyncToken
         - event: EndAsyncToken(address,address,address,uint256,string,string,uint256,uint256,bool,uint256)
           handler: handleEndAsyncToken
-      blockHandlers:
-        - handler: handleTokenURISafeguard
-          filter:
-            kind: polling
-            every: 75 # approx every 2.5 minutes
   - kind: ethereum/contract
     name: UBO
     network: matic
@@ -365,6 +360,8 @@ dataSources:
       eventHandlers:
         - event: VCUOMinted(address,uint256)
           handler: handleVCUOMinted
+        - event: VCUOMetaDataUpdated(uint256,string)
+          handler: handleVCUOMetaDataUpdated
   - kind: ethereum/contract
     name: ICRCarbonContractRegistry
     network: matic


### PR DESCRIPTION
Previously used a blockHandler to check for tokenUris set after the project was minted.

Removed the blockHandler and using the event emitted by the set metadata function instead. This matches the tokenId in the event to the nft index in the `C3RetireRequest` to set the url in the event params.

test deployment: https://api.studio.thegraph.com/query/28985/digital-carbon-sandbox/VCUOMetadUpdated-handler