### PR TITLE
Handle reverted C3 finalizations for async retires

### DIFF
--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -336,15 +336,15 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           safeguard.requestsWithoutURI = requestsArray
           safeguard.save()
           log.error('Retrieved tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
+        } else {
+          request.tokenURI = tokenURI
         }
-        request.tokenURI = tokenURI
       }
 
       request.status = BridgeStatus.FINALIZED
-      request.save()
     } else if (request.status == BridgeStatus.REQUESTED && event.params.success == false) {
       request.status = BridgeStatus.REVERTED
-      request.save()
     }
   }
+  request.save()
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -314,7 +314,7 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
     ])
     return
   } else {
-    if (request.status == BridgeStatus.REQUESTED) {
+    if (request.status == BridgeStatus.REQUESTED && event.params.success == true) {
       let c3OffsetNftContract = C3OffsetNFT.bind(C3_VERIFIED_CARBON_UNITS_OFFSET)
 
       let tokenURICall = c3OffsetNftContract.try_tokenURI(event.params.nftIndex)
@@ -341,6 +341,9 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
       }
 
       request.status = BridgeStatus.FINALIZED
+      request.save()
+    } else if (request.status == BridgeStatus.REQUESTED && event.params.success == false) {
+      request.status = BridgeStatus.REVERTED
       request.save()
     }
   }


### PR DESCRIPTION
Previously all retires were assumed to be valid if EndAsyncToken was emitted. However there is a success param in the event which is now tracked and will assign `FINALIZED` or `REVERTED` accordingly.