### PR TITLE
Return largest Puro batch id based on batchStatus

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -41,15 +41,14 @@ enum BridgeStatus {
 }
 
 enum ToucanBatchStatus {
-    Pending, 
-    Rejected, 
-    Confirmed, 
-    DetokenizationRequested, 
-    DetokenizationFinalized, 
-    RetirementRequested, 
-    RetirementFinalized
+  Pending
+  Rejected
+  Confirmed
+  DetokenizationRequested
+  DetokenizationFinalized
+  RetirementRequested
+  RetirementFinalized
 }
-
 
 type ProvenanceRecord @entity {
   "Token address - Holding address - increment"
@@ -248,9 +247,6 @@ type CarbonCredit @entity {
   # Puro specific fields
   "Puro NFT token ID linked to Puro batch"
   puroBatchTokenId: BigInt
-  
-  "Remaining batch size linked to batch token ID"
-  maxRetireAmount: BigInt
 }
 
 type CarbonCreditSnapshot @entity {

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -40,6 +40,17 @@ enum BridgeStatus {
   AWAITING
 }
 
+enum ToucanBatchStatus {
+    Pending, 
+    Rejected, 
+    Confirmed, 
+    DetokenizationRequested, 
+    DetokenizationFinalized, 
+    RetirementRequested, 
+    RetirementFinalized
+}
+
+
 type ProvenanceRecord @entity {
   "Token address - Holding address - increment"
   id: Bytes!
@@ -237,6 +248,9 @@ type CarbonCredit @entity {
   # Puro specific fields
   "Puro NFT token ID linked to Puro batch"
   puroBatchTokenId: BigInt
+  
+  "Remaining batch size linked to batch token ID"
+  maxRetireAmount: BigInt
 }
 
 type CarbonCreditSnapshot @entity {

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -40,16 +40,6 @@ enum BridgeStatus {
   AWAITING
 }
 
-enum ToucanBatchStatus {
-  Pending
-  Rejected
-  Confirmed
-  DetokenizationRequested
-  DetokenizationFinalized
-  RetirementRequested
-  RetirementFinalized
-}
-
 type ProvenanceRecord @entity {
   "Token address - Holding address - increment"
   id: Bytes!

--- a/polygon-digital-carbon/src/KlimaAggregator.ts
+++ b/polygon-digital-carbon/src/KlimaAggregator.ts
@@ -3,13 +3,15 @@ import { ToucanRetired } from '../generated/RetireToucanCarbon/RetireToucanCarbo
 import { C3Retired } from '../generated/RetireC3Carbon/RetireC3Carbon'
 import { CarbonRetired, CarbonRetired1 as CarbonRetiredTokenId } from '../generated/KlimaInfinity/KlimaInfinity'
 import { KlimaCarbonRetirements } from '../generated/RetireC3Carbon/KlimaCarbonRetirements'
-import { BigInt, dataSource } from '@graphprotocol/graph-ts'
+import { Address, BigInt, dataSource } from '@graphprotocol/graph-ts'
 import { loadOrCreateAccount } from './utils/Account'
 import { loadRetire } from './utils/Retire'
 import { ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { saveKlimaRetire } from './utils/KlimaRetire'
 import { ZERO_BI } from '../../lib/utils/Decimals'
 import { getRetirementsContractAddress } from '../utils/getRetirementsContractAddress'
+import { loadCarbonCredit, updateCarbonCreditWithCall } from './utils/CarbonCredit'
+import { CarbonProject } from '../generated/schema'
 
 export function handleMossRetired(event: MossRetired): void {
   // Ignore zero value retirements
@@ -170,6 +172,17 @@ export function handleCarbonRetiredWithTokenId(event: CarbonRetiredTokenId): voi
   retire.retiringAddress = event.params.retiringAddress
   retire.retirementMessage = event.params.retirementMessage
   retire.save()
+
+  let credit = loadCarbonCredit(retire.credit)
+  let project = CarbonProject.load(credit.project) as CarbonProject
+
+  // update the credit with the largest batch and remaining quantity
+  if (project != null) {
+    if (project.registry == 'PURO_EARTH') {
+      updateCarbonCreditWithCall(Address.fromBytes(credit.id), project.registry)
+    }
+  }
+
 
   saveKlimaRetire(
     event.params.beneficiaryAddress,

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -92,8 +92,6 @@ function updateToucanCall(tokenAddress: Address, carbonCredit: CarbonCredit, reg
       let projectVintageTokenIdFromNftList = nftData.value0
       let quantity = nftData.value1
       let batchStatus = nftData.value2
-      
-
       if (projectVintageTokenIdFromNftList == projectVintageTokenId) {
         carbonCredit.puroBatchTokenId = tokenIds[i]
         // break
@@ -102,24 +100,27 @@ function updateToucanCall(tokenAddress: Address, carbonCredit: CarbonCredit, reg
         // if the batch status is 5 then the whole batch is being requested for retirement
         // If a retirement is requested for less than a whole batch a new batch will be created with the requested amount
         // and the original batch is be updated with the remaining amount that has not been requested
-        batchAndQuantity[1] = (batchStatus == 5) ? BigInt.fromI32(0) : quantity
+        // if the batch status is 6 then the whole batch has been retired and is no longer available for retirement
+        batchAndQuantity[1] =( batchStatus == 5 || batchStatus == 6) ? BigInt.fromI32(0) : quantity
 
         batchesAndQuantities.push(batchAndQuantity)
       }
 
       let maxQuantity: BigInt = BigInt.fromI32(0)
       let maxBatchTokenId: BigInt = BigInt.fromI32(0)
-  
+
       for (let i = 0; i < batchesAndQuantities.length; i++) {
         let currentBatchTokenId: BigInt = batchesAndQuantities[i][0]
         let currentQuantity: BigInt = batchesAndQuantities[i][1]
-  
+        // issue here if quantity is 0 then batch token id won't be set
         if (currentQuantity > maxQuantity) {
           maxQuantity = currentQuantity
           maxBatchTokenId = currentBatchTokenId
+        } else if (currentQuantity == BigInt.fromI32(0) && maxQuantity == BigInt.fromI32(0)) {
+          maxBatchTokenId = currentBatchTokenId
         }
       }
-  
+
       carbonCredit.puroBatchTokenId = maxBatchTokenId
       carbonCredit.maxRetireAmount = maxQuantity
     }

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -97,11 +97,25 @@ function updateToucanCall(tokenAddress: Address, carbonCredit: CarbonCredit, reg
         // break
         let batchAndQuantity: Array<BigInt> = new Array<BigInt>(2)
         batchAndQuantity[0] = tokenIds[i]
+
+        // Toucan BatchStatus enum
+        //   enum BatchStatus {
+        //     Pending, // 0
+        //     Rejected, // 1
+        //     Confirmed, // 2
+        //     DetokenizationRequested, // 3
+        //     DetokenizationFinalized, // 4
+        //     RetirementRequested, // 5
+        //     RetirementFinalized // 6
+        // }
+
+        // If the batch status is 2 then those credits are confirmed and avaiable for retirement
         // if the batch status is 5 then the whole batch is being requested for retirement
-        // If a retirement is requested for less than a whole batch a new batch will be created with the requested amount
+        // If a retirement is requested for less than a whole batch a new batch with a new batch token id will be created with the requested amount
         // and the original batch is be updated with the remaining amount that has not been requested
         // if the batch status is 6 then the whole batch has been retired and is no longer available for retirement
-        batchAndQuantity[1] =( batchStatus == 5 || batchStatus == 6) ? BigInt.fromI32(0) : quantity
+
+        batchAndQuantity[1] = batchStatus == 2 ? quantity : BigInt.fromI32(0)
 
         batchesAndQuantities.push(batchAndQuantity)
       }

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -136,7 +136,6 @@ function updateToucanCall(tokenAddress: Address, carbonCredit: CarbonCredit, reg
       }
 
       carbonCredit.puroBatchTokenId = maxBatchTokenId
-      carbonCredit.maxRetireAmount = maxQuantity
     }
   }
 

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -76,10 +76,10 @@ dataSources:
         - name: ToucanContractRegistry
           file: ../lib/abis/ToucanContractRegistry.json      
         - name: ToucanCarbonOffsetBatches
-          file: ../lib/abis/ToucanCarbonOffsetBatches.json    
+          file: ../lib/abis/ToucanCarbonOffsetBatches.json       
       eventHandlers:
         - event: TokenCreated(uint256,address)
-          handler: handleNewPuroTCO2       
+          handler: handleNewPuroTCO2 
   - kind: ethereum/contract
     name: ToucanCarbonOffsetBatch
     network: {{network}}
@@ -480,6 +480,12 @@ dataSources:
           file: ../lib/abis/KlimaCarbonRetirements.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
+        - name: ToucanCarbonOffsets
+          file: ../lib/abis/ToucanCarbonOffsets.json
+        - name: ToucanContractRegistry
+          file: ../lib/abis/ToucanContractRegistry.json  
+        - name: ToucanCarbonOffsetBatches
+          file: ../lib/abis/ToucanCarbonOffsetBatches.json            
       eventHandlers:
         - event: CarbonRetired(uint8,indexed address,string,indexed address,string,string,indexed address,address,uint256)
           handler: handleCarbonRetired

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -76,10 +76,10 @@ dataSources:
         - name: ToucanContractRegistry
           file: ../lib/abis/ToucanContractRegistry.json      
         - name: ToucanCarbonOffsetBatches
-          file: ../lib/abis/ToucanCarbonOffsetBatches.json    
+          file: ../lib/abis/ToucanCarbonOffsetBatches.json       
       eventHandlers:
         - event: TokenCreated(uint256,address)
-          handler: handleNewPuroTCO2       
+          handler: handleNewPuroTCO2 
   - kind: ethereum/contract
     name: ToucanCarbonOffsetBatch
     network: matic
@@ -480,6 +480,12 @@ dataSources:
           file: ../lib/abis/KlimaCarbonRetirements.json
         - name: ERC20
           file: ../lib/abis/ERC20.json
+        - name: ToucanCarbonOffsets
+          file: ../lib/abis/ToucanCarbonOffsets.json
+        - name: ToucanContractRegistry
+          file: ../lib/abis/ToucanContractRegistry.json  
+        - name: ToucanCarbonOffsetBatches
+          file: ../lib/abis/ToucanCarbonOffsetBatches.json            
       eventHandlers:
         - event: CarbonRetired(uint8,indexed address,string,indexed address,string,string,indexed address,address,uint256)
           handler: handleCarbonRetired


### PR DESCRIPTION
This PR returns the batch Id based on the largest available batch with the correct status for credits available for retirement, batchStatus of 2.

This should only be a future safeguard, as to the best of my knowledge no credits have been bridged in multiple batches yet. 

In the current implementation on main (currently 1716 batchIds):
1) If the batch is 5 (id 1713) and there is a sub-batch retirement request for 1 -->
2) The toucan contract will be create a new batch with id 1717 with a retirement requested status and update 1713 to 4 while keeping the batchStatus 2.
3) Thus in the current implementation, the subgraph will still return the the correct batch with the largest quantity.
4) This PR is necessary for selecting the largest batch in case additional existing credits are bridged.
5) This does not enable returning all valid for retirement batches relating to a credit as the RA does not currently support. Follow up PR necessary for that.