### PR TITLE
[`digital-carbon`] c3 async finalization updates `bridgeStatus` on `Retire`

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -413,7 +413,7 @@ type C3RetireRequest @entity {
   index: BigInt!
   c3OffsetNftIndex: BigInt!
   status: BridgeStatus!
-  retire: Retire
+  retire: Retire!
   provenance: ProvenanceRecord
   tokenURI: String!
   retirementMetadata: C3RetirementMetadata

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -347,6 +347,14 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
         }
       }
 
+      // set status on retire as well
+      let retireId = request.retire
+
+      if (retireId != null) {
+        let retire = loadRetire(retireId)
+        retire.bridgeStatus = BridgeStatus.FINALIZED
+      }
+
       request.status = BridgeStatus.FINALIZED
     } else if (request.status == BridgeStatus.REQUESTED && event.params.success == false) {
       request.status = BridgeStatus.REVERTED

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -310,9 +310,7 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
   let request = loadC3RetireRequest(requestId)
 
   if (request == null) {
-    log.error('No C3RetireRequest found for retireId: {} hash: {}', [
-      event.transaction.hash.toHexString(),
-    ])
+    log.error('No C3RetireRequest found for retireId: {} hash: {}', [event.transaction.hash.toHexString()])
     return
   } else {
     if (request.status == BridgeStatus.REQUESTED && event.params.success == true) {
@@ -337,7 +335,9 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           requestsArray.push(requestId)
           safeguard.requestsWithoutURI = requestsArray
           safeguard.save()
-          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
+          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [
+            event.params.nftIndex.toString(),
+          ])
         } else {
           request.tokenURI = tokenURI
           const hash = extractIpfsHash(tokenURI)
@@ -348,14 +348,10 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
       }
 
       // set status on retire as well
-      let retireId: Bytes | null = request.retire
+      let retireId: Bytes = request.retire
 
-      if (retireId === null) {
-        log.info('RetireId is null for requestId: {}', [requestId.toHexString()])
-      } else {
-        let retire = loadRetire(retireId)
-        retire.bridgeStatus = BridgeStatus.FINALIZED
-      }
+      let retire = loadRetire(retireId)
+      retire.bridgeStatus = BridgeStatus.FINALIZED
 
       request.status = BridgeStatus.FINALIZED
     } else if (request.status == BridgeStatus.REQUESTED && event.params.success == false) {
@@ -378,9 +374,8 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
   /** Target the request with the index that matches the event.params.tokenId
    * With event.params.tokenId, it's theoretically possible to call .list() on the C3OffsetNFT contract to get the project address
    * However the issue is the request cannot be loaded as the request id is project address.concat(with retirement index)
-   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or 
-   * credit contract with any of the event params to retrieve the retirement index  */ 
-
+   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or
+   * credit contract with any of the event params to retrieve the retirement index  */
 
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -15,7 +15,7 @@ import { incrementAccountRetirements, loadOrCreateAccount } from './utils/Accoun
 import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit'
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { loadRetire, saveRetire } from './utils/Retire'
-import { log } from '@graphprotocol/graph-ts'
+import { log, Bytes } from '@graphprotocol/graph-ts'
 import { loadOrCreateC3RetireRequest, loadC3RetireRequest } from './utils/C3'
 import { Token, TokenURISafeguard } from '../generated/schema'
 import { getC3RetireRequestId } from '../utils/getRetirementsContractAddress'
@@ -348,9 +348,11 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
       }
 
       // set status on retire as well
-      let retireId = request.retire
+      let retireId: Bytes | null = request.retire
 
-      if (retireId != null) {
+      if (retireId === null) {
+        log.info('RetireId is null for requestId: {}', [requestId.toHexString()])
+      } else {
         let retire = loadRetire(retireId)
         retire.bridgeStatus = BridgeStatus.FINALIZED
       }

--- a/polygon-digital-carbon/src/utils/C3.ts
+++ b/polygon-digital-carbon/src/utils/C3.ts
@@ -9,6 +9,7 @@ export function loadOrCreateC3RetireRequest(requestId: Bytes): C3RetireRequest {
     request = new C3RetireRequest(requestId)
     request.status = BridgeStatus.AWAITING
     request.index = BigInt.fromI32(0)
+    request.retire = new Bytes(0)
     request.c3OffsetNftIndex = BigInt.fromI32(0)
     request.tokenURI = ''
     request.save()


### PR DESCRIPTION
Updates the `Retire` entity `bridgeStatus` when C3 async retires complete

converted to draft because this PR: https://github.com/KlimaDAO/klima-subgraph/pull/176 would override this one 