### PR TITLE
[`digital-carbon`]  Use file data sources for C3 async retirement metadata

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -418,6 +418,38 @@ type C3RetireRequest @entity {
   tokenURI: String!
 }
 
+# C3Project and C3RetirementMetadata are used for file datasources for C3 metadata
+type C3MetadataProject @entity {
+  id: ID!
+  name: String!
+  project_id: String!
+  project_type: String!
+  registry: String!
+  region: String!
+  country: String!
+  methodology: String!
+  period_start: String!
+  period_end: String!
+  ac: Boolean!
+  uri: String!
+}
+
+type C3RetirementMetadata @entity {
+  id: ID!
+  transferee: String!
+  reason: String!
+  projectId: String!
+  projectAddress: Bytes!
+  amount: Int!
+  vintage: String!
+  owner: Bytes!
+  project: C3MetadataProject!
+  image: String!
+  pdf: String!
+  nftRegistry: String!
+}
+
+
 # id is always and only safeguard
 type TokenURISafeguard @entity {
   "Token URI"

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -421,32 +421,32 @@ type C3RetireRequest @entity {
 # C3Project and C3RetirementMetadata are used for file datasources for C3 metadata
 type C3MetadataProject @entity {
   id: ID!
-  name: String!
-  project_id: String!
-  project_type: String!
-  registry: String!
-  region: String!
-  country: String!
-  methodology: String!
-  period_start: String!
-  period_end: String!
-  ac: Boolean!
-  uri: String!
+  name: String
+  project_id: String
+  project_type: String
+  registry: String
+  region: String
+  country: String
+  methodology: String
+  period_start: String
+  period_end: String
+  ac: Boolean
+  uri: String
 }
 
 type C3RetirementMetadata @entity {
   id: ID!
-  transferee: String!
-  reason: String!
-  projectId: String!
-  projectAddress: Bytes!
-  amount: Int!
-  vintage: String!
-  owner: Bytes!
-  project: C3MetadataProject!
-  image: String!
-  pdf: String!
-  nftRegistry: String!
+  transferee: String
+  reason: String
+  projectId: String
+  projectAddress: Bytes
+  amount: Int
+  vintage: String
+  owner: Bytes
+  project: C3MetadataProject
+  image: String
+  pdf: String
+  nftRegistry: String
 }
 
 

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -416,6 +416,7 @@ type C3RetireRequest @entity {
   retire: Retire
   provenance: ProvenanceRecord
   tokenURI: String!
+  retirementMetadata: C3RetirementMetadata
 }
 
 # C3Project and C3RetirementMetadata are used for file datasources for C3 metadata

--- a/polygon-digital-carbon/src/MetadataHandler.ts
+++ b/polygon-digital-carbon/src/MetadataHandler.ts
@@ -1,0 +1,66 @@
+
+  import {  Bytes, json, dataSource } from '@graphprotocol/graph-ts'
+  import { C3RetirementMetadata, C3MetadataProject} from '../generated/schema'
+
+
+export function handleC3RetirementMetadata(content: Bytes): void {
+    let c3RetirementMetadata = new C3RetirementMetadata(dataSource.stringParam())
+    const value = json.fromBytes(content).toObject()
+    if (value) {
+      const transferee = value.get('transferee')
+      const reason = value.get('reason')
+      const projectId = value.get('projectId')
+      const projectAddress = value.get('projectAddress')
+      const amount = value.get('amount')
+      const vintage = value.get('vintage')
+      const owner = value.get('owner')
+      const uncheckedProject = value.get('project')
+      const image = value.get('image')
+      const pdf = value.get('pdf')
+      const nftRegistry = value.get('nftRegistry')
+  
+      if (transferee) c3RetirementMetadata.transferee = transferee.toString()
+      if (reason) c3RetirementMetadata.reason = reason.toString()
+      if (projectId) c3RetirementMetadata.projectId = projectId.toString()
+      if (projectAddress) c3RetirementMetadata.projectAddress = Bytes.fromHexString(projectAddress.toString())
+      if (amount) c3RetirementMetadata.amount = amount.toBigInt().toI32()
+      if (vintage) c3RetirementMetadata.vintage = vintage.toString()
+      if (owner) c3RetirementMetadata.owner = Bytes.fromHexString(owner.toString())
+      if (image) c3RetirementMetadata.image = image.toString()
+      if (pdf) c3RetirementMetadata.pdf = pdf.toString()
+      if (nftRegistry) c3RetirementMetadata.nftRegistry = nftRegistry.toString()
+  
+      if (uncheckedProject) {
+        const project = uncheckedProject.toObject()
+        let projectEntity = new C3MetadataProject(c3RetirementMetadata.id)
+        const projectName = project.get('name')
+        const project_id = project.get('project_id')
+        const project_type = project.get('project_type')
+        const registry = project.get('registry')
+        const region = project.get('region')
+        const country = project.get('country')
+        const methodology = project.get('methodology')
+        const period_start = project.get('period_start')
+        const period_end = project.get('period_end')
+        const ac = project.get('ac')
+        const uri = project.get('uri')
+  
+        if (projectName) projectEntity.name = projectName.toString()
+        if (project_id) projectEntity.project_id = project_id.toString()
+        if (project_type) projectEntity.project_type = project_type.toString()
+        if (registry) projectEntity.registry = registry.toString()
+        if (region) projectEntity.region = region.toString()
+        if (country) projectEntity.country = country.toString()
+        if (methodology) projectEntity.methodology = methodology.toString()
+        if (period_start) projectEntity.period_start = period_start.toString()
+        if (period_end) projectEntity.period_end = period_end.toString()
+        if (ac) projectEntity.ac = ac.toBool()
+        if (uri) projectEntity.uri = uri.toString()
+  
+        projectEntity.save()
+        c3RetirementMetadata.project = projectEntity.id
+      }
+  
+      c3RetirementMetadata.save()
+    }
+  }

--- a/polygon-digital-carbon/src/MetadataHandler.ts
+++ b/polygon-digital-carbon/src/MetadataHandler.ts
@@ -1,66 +1,63 @@
-
-  import {  Bytes, json, dataSource } from '@graphprotocol/graph-ts'
-  import { C3RetirementMetadata, C3MetadataProject} from '../generated/schema'
-
+import { Bytes, json, dataSource } from '@graphprotocol/graph-ts'
+import { C3RetirementMetadata, C3MetadataProject } from '../generated/schema'
 
 export function handleC3RetirementMetadata(content: Bytes): void {
-    let c3RetirementMetadata = new C3RetirementMetadata(dataSource.stringParam())
-    const value = json.fromBytes(content).toObject()
-    if (value) {
-      const transferee = value.get('transferee')
-      const reason = value.get('reason')
-      const projectId = value.get('projectId')
-      const projectAddress = value.get('projectAddress')
-      const amount = value.get('amount')
-      const vintage = value.get('vintage')
-      const owner = value.get('owner')
-      const uncheckedProject = value.get('project')
-      const image = value.get('image')
-      const pdf = value.get('pdf')
-      const nftRegistry = value.get('nftRegistry')
-  
-      if (transferee) c3RetirementMetadata.transferee = transferee.toString()
-      if (reason) c3RetirementMetadata.reason = reason.toString()
-      if (projectId) c3RetirementMetadata.projectId = projectId.toString()
-      if (projectAddress) c3RetirementMetadata.projectAddress = Bytes.fromHexString(projectAddress.toString())
-      if (amount) c3RetirementMetadata.amount = amount.toBigInt().toI32()
-      if (vintage) c3RetirementMetadata.vintage = vintage.toString()
-      if (owner) c3RetirementMetadata.owner = Bytes.fromHexString(owner.toString())
-      if (image) c3RetirementMetadata.image = image.toString()
-      if (pdf) c3RetirementMetadata.pdf = pdf.toString()
-      if (nftRegistry) c3RetirementMetadata.nftRegistry = nftRegistry.toString()
-  
-      if (uncheckedProject) {
-        const project = uncheckedProject.toObject()
-        let projectEntity = new C3MetadataProject(c3RetirementMetadata.id)
-        const projectName = project.get('name')
-        const project_id = project.get('project_id')
-        const project_type = project.get('project_type')
-        const registry = project.get('registry')
-        const region = project.get('region')
-        const country = project.get('country')
-        const methodology = project.get('methodology')
-        const period_start = project.get('period_start')
-        const period_end = project.get('period_end')
-        const ac = project.get('ac')
-        const uri = project.get('uri')
-  
-        if (projectName) projectEntity.name = projectName.toString()
-        if (project_id) projectEntity.project_id = project_id.toString()
-        if (project_type) projectEntity.project_type = project_type.toString()
-        if (registry) projectEntity.registry = registry.toString()
-        if (region) projectEntity.region = region.toString()
-        if (country) projectEntity.country = country.toString()
-        if (methodology) projectEntity.methodology = methodology.toString()
-        if (period_start) projectEntity.period_start = period_start.toString()
-        if (period_end) projectEntity.period_end = period_end.toString()
-        if (ac) projectEntity.ac = ac.toBool()
-        if (uri) projectEntity.uri = uri.toString()
-  
-        projectEntity.save()
-        c3RetirementMetadata.project = projectEntity.id
-      }
-  
-      c3RetirementMetadata.save()
+  let c3RetirementMetadata = new C3RetirementMetadata(dataSource.stringParam())
+  const value = json.fromBytes(content).toObject()
+  if (value) {
+    const transferee = value.get('transferee')
+    const reason = value.get('reason')
+    const projectId = value.get('projectId')
+    const projectAddress = value.get('projectAddress')
+    const amount = value.get('amount')
+    const vintage = value.get('vintage')
+    const owner = value.get('owner')
+    const uncheckedProject = value.get('project')
+    const image = value.get('image')
+    const pdf = value.get('pdf')
+    const nftRegistry = value.get('nftRegistry')
+
+    if (transferee) c3RetirementMetadata.transferee = transferee.toString()
+    if (reason) c3RetirementMetadata.reason = reason.toString()
+    if (projectId) c3RetirementMetadata.projectId = projectId.toString()
+    if (projectAddress) c3RetirementMetadata.projectAddress = Bytes.fromHexString(projectAddress.toString())
+    if (amount) c3RetirementMetadata.amount = amount.toBigInt().toI32()
+    if (vintage) c3RetirementMetadata.vintage = vintage.toString()
+    if (owner) c3RetirementMetadata.owner = Bytes.fromHexString(owner.toString())
+    if (image) c3RetirementMetadata.image = image.toString()
+    if (pdf) c3RetirementMetadata.pdf = pdf.toString()
+    if (nftRegistry) c3RetirementMetadata.nftRegistry = nftRegistry.toString()
+
+    if (uncheckedProject) {
+      const project = uncheckedProject.toObject()
+      let projectEntity = new C3MetadataProject(c3RetirementMetadata.id)
+      const projectName = project.get('name')
+      const project_id = project.get('project_id')
+      const project_type = project.get('project_type')
+      const registry = project.get('registry')
+      const region = project.get('region')
+      const country = project.get('country')
+      const methodology = project.get('methodology')
+      const period_start = project.get('period_start')
+      const period_end = project.get('period_end')
+      const ac = project.get('ac')
+      const uri = project.get('uri')
+
+      if (projectName) projectEntity.name = projectName.toString()
+      if (project_id) projectEntity.project_id = project_id.toString()
+      if (project_type) projectEntity.project_type = project_type.toString()
+      if (registry) projectEntity.registry = registry.toString()
+      if (region) projectEntity.region = region.toString()
+      if (country) projectEntity.country = country.toString()
+      if (methodology) projectEntity.methodology = methodology.toString()
+      if (period_start) projectEntity.period_start = period_start.toString()
+      if (period_end) projectEntity.period_end = period_end.toString()
+      if (ac) projectEntity.ac = ac.toBool()
+      if (uri) projectEntity.uri = uri.toString()
+
+      projectEntity.save()
+      c3RetirementMetadata.project = projectEntity.id
     }
   }
+  c3RetirementMetadata.save()
+}

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -15,12 +15,13 @@ import { incrementAccountRetirements, loadOrCreateAccount } from './utils/Accoun
 import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit'
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { loadRetire, saveRetire } from './utils/Retire'
-import { log } from '@graphprotocol/graph-ts'
+import { log, Bytes, json, dataSource } from '@graphprotocol/graph-ts'
 import { loadOrCreateC3RetireRequest, loadC3RetireRequest } from './utils/C3'
-import { Token, TokenURISafeguard } from '../generated/schema'
+import { C3RetirementMetadata, C3MetadataProject, Token, TokenURISafeguard } from '../generated/schema'
 import { getC3RetireRequestId } from '../utils/getRetirementsContractAddress'
 import { BridgeStatus } from '../utils/enums'
 import { loadOrCreateToucanBridgeRequest } from './utils/Toucan'
+import { C3RetirementMetadata as C3RetirementMetadataTemplate } from '../generated/templates'
 
 export function saveToucanRetirement(event: Retired): void {
   // Disregard events with zero amount
@@ -339,6 +340,8 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           log.error('Retrieved tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
         } else {
           request.tokenURI = tokenURI
+
+          C3RetirementMetadataTemplate.create(tokenURI)
         }
       }
 
@@ -370,8 +373,74 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
     }
 
     if (request.c3OffsetNftIndex == event.params.tokenId) {
-      request.tokenURI = event.params.url
+      const tokenURI = event.params.url
+
+      request.tokenURI = tokenURI
       request.save()
+
+      C3RetirementMetadataTemplate.create(tokenURI)
     }
+  }
+}
+
+export function handleC3RetirementMetadata(content: Bytes): void {
+  let c3RetirementMetadata = new C3RetirementMetadata(dataSource.stringParam())
+  const value = json.fromBytes(content).toObject()
+  if (value) {
+    const transferee = value.get('transferee')
+    const reason = value.get('reason')
+    const projectId = value.get('projectId')
+    const projectAddress = value.get('projectAddress')
+    const amount = value.get('amount')
+    const vintage = value.get('vintage')
+    const owner = value.get('owner')
+    const uncheckedProject = value.get('project')
+    const image = value.get('image')
+    const pdf = value.get('pdf')
+    const nftRegistry = value.get('nftRegistry')
+
+    if (transferee) c3RetirementMetadata.transferee = transferee.toString()
+    if (reason) c3RetirementMetadata.reason = reason.toString()
+    if (projectId) c3RetirementMetadata.projectId = projectId.toString()
+    if (projectAddress) c3RetirementMetadata.projectAddress = Bytes.fromHexString(projectAddress.toString())
+    if (amount) c3RetirementMetadata.amount = amount.toBigInt().toI32()
+    if (vintage) c3RetirementMetadata.vintage = vintage.toString()
+    if (owner) c3RetirementMetadata.owner = Bytes.fromHexString(owner.toString())
+    if (image) c3RetirementMetadata.image = image.toString()
+    if (pdf) c3RetirementMetadata.pdf = pdf.toString()
+    if (nftRegistry) c3RetirementMetadata.nftRegistry = nftRegistry.toString()
+
+    if (uncheckedProject) {
+      const project = uncheckedProject.toObject()
+      let projectEntity = new C3MetadataProject(c3RetirementMetadata.id)
+      const projectName = project.get('name')
+      const project_id = project.get('project_id')
+      const project_type = project.get('project_type')
+      const registry = project.get('registry')
+      const region = project.get('region')
+      const country = project.get('country')
+      const methodology = project.get('methodology')
+      const period_start = project.get('period_start')
+      const period_end = project.get('period_end')
+      const ac = project.get('ac')
+      const uri = project.get('uri')
+
+      if (projectName) projectEntity.name = projectName.toString()
+      if (project_id) projectEntity.project_id = project_id.toString()
+      if (project_type) projectEntity.project_type = project_type.toString()
+      if (registry) projectEntity.registry = registry.toString()
+      if (region) projectEntity.region = region.toString()
+      if (country) projectEntity.country = country.toString()
+      if (methodology) projectEntity.methodology = methodology.toString()
+      if (period_start) projectEntity.period_start = period_start.toString()
+      if (period_end) projectEntity.period_end = period_end.toString()
+      if (ac) projectEntity.ac = ac.toBool()
+      if (uri) projectEntity.uri = uri.toString()
+
+      projectEntity.save()
+      c3RetirementMetadata.project = projectEntity.id
+    }
+
+    c3RetirementMetadata.save()
   }
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -342,7 +342,7 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
         } else {
           request.tokenURI = tokenURI
           request.retirementMetadata = tokenURI
-          
+
           const hash = extractIpfsHash(tokenURI)
           C3RetirementMetadataTemplate.create(hash)
         }
@@ -380,10 +380,11 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
 
       request.tokenURI = tokenURI
       request.retirementMetadata = tokenURI
-      request.save()
 
       const hash = extractIpfsHash(tokenURI)
       C3RetirementMetadataTemplate.create(hash)
+
+      request.save()
     }
   }
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -311,7 +311,6 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
 
   if (request == null) {
     log.error('No C3RetireRequest found for retireId: {} hash: {}', [
-      // retireId.toHexString(),
       event.transaction.hash.toHexString(),
     ])
     return
@@ -338,7 +337,7 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           requestsArray.push(requestId)
           safeguard.requestsWithoutURI = requestsArray
           safeguard.save()
-          log.error('Retrieved tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
+          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
         } else {
           request.tokenURI = tokenURI
           const hash = extractIpfsHash(tokenURI)
@@ -366,7 +365,13 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
   let requestsArray = safeguard.requestsWithoutURI
   if (requestsArray.length == 0) return
 
-  // target the request with the index that matches the event.params.tokenId
+  /** Target the request with the index that matches the event.params.tokenId
+   * With event.params.tokenId, it's theoretically possible to call .list() on the C3OffsetNFT contract to get the project address
+   * However the issue is the request cannot be loaded as the request id is project address.concat(with retirement index)
+   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or 
+   * credit contract with any of the event params to retrieve the retirement index  */ 
+
+
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]
     let request = loadC3RetireRequest(requestId)

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -22,6 +22,7 @@ import { getC3RetireRequestId } from '../utils/getRetirementsContractAddress'
 import { BridgeStatus } from '../utils/enums'
 import { loadOrCreateToucanBridgeRequest } from './utils/Toucan'
 import { C3RetirementMetadata as C3RetirementMetadataTemplate } from '../generated/templates'
+import { extractIpfsHash } from '../utils/ipfs'
 
 export function saveToucanRetirement(event: Retired): void {
   // Disregard events with zero amount
@@ -341,7 +342,9 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
         } else {
           request.tokenURI = tokenURI
           request.retirementMetadata = tokenURI
-          C3RetirementMetadataTemplate.create(tokenURI)
+          
+          const hash = extractIpfsHash(tokenURI)
+          C3RetirementMetadataTemplate.create(hash)
         }
       }
 
@@ -379,7 +382,8 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
       request.retirementMetadata = tokenURI
       request.save()
 
-      C3RetirementMetadataTemplate.create(tokenURI)
+      const hash = extractIpfsHash(tokenURI)
+      C3RetirementMetadataTemplate.create(hash)
     }
   }
 }

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -341,9 +341,9 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           log.error('Retrieved tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
         } else {
           request.tokenURI = tokenURI
-          request.retirementMetadata = tokenURI
-
           const hash = extractIpfsHash(tokenURI)
+
+          request.retirementMetadata = hash
           C3RetirementMetadataTemplate.create(hash)
         }
       }
@@ -379,9 +379,9 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
       const tokenURI = event.params.url
 
       request.tokenURI = tokenURI
-      request.retirementMetadata = tokenURI
-
       const hash = extractIpfsHash(tokenURI)
+
+      request.retirementMetadata = hash
       C3RetirementMetadataTemplate.create(hash)
 
       request.save()

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -3,6 +3,11 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
+features:
+  - grafting
+graft:
+  base: QmYaGZwuyGsCKyPzKLqLrUtVxubJXTFj8953X7Fm1QyUXd
+  block: 57961533
 dataSources:
   - kind: ethereum/contract
     name: CarbonProjectsAddress  
@@ -631,6 +636,7 @@ templates:
       entities:
         - C3RetireRequest      
         - C3RetirementMetadata
+        - C3MetadataProject
       abis:
         - name: ICRProjectToken
           file: ../lib/abis/ICRProjectToken.json

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -572,8 +572,7 @@ templates:
           handler: handleToucanPuroRetirementReverted
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleCreditTransfer
-      file: ./src/TransferHandler.ts   
-         
+      file: ./src/TransferHandler.ts    
   - name: C3ProjectToken
     kind: ethereum/contract
     network: {{network}}
@@ -622,3 +621,16 @@ templates:
         - event: ExAnteMinted(indexed uint256,indexed uint256,indexed address,uint256)
           handler: handleExAnteMinted
       file: ./src/TransferHandler.ts
+  - name: C3RetirementMetadata
+    kind: file/ipfs
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/RetirementHandler.ts
+      handler: handleC3RetirementMetadata
+      entities:
+        - C3RetireRequest      
+        - C3RetirementMetadata
+      abis:
+        - name: ICRProjectToken
+          file: ../lib/abis/ICRProjectToken.json

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -626,7 +626,7 @@ templates:
     mapping:
       apiVersion: 0.0.7
       language: wasm/assemblyscript
-      file: ./src/RetirementHandler.ts
+      file: ./src/MetadataHandler.ts
       handler: handleC3RetirementMetadata
       entities:
         - C3RetireRequest      

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -3,11 +3,6 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
-features:
-  - grafting
-graft:
-  base: QmYaGZwuyGsCKyPzKLqLrUtVxubJXTFj8953X7Fm1QyUXd
-  block: 57961533
 dataSources:
   - kind: ethereum/contract
     name: CarbonProjectsAddress  

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -3,11 +3,6 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
-features:
-  - grafting
-graft:
-  base: QmYaGZwuyGsCKyPzKLqLrUtVxubJXTFj8953X7Fm1QyUXd
-  block: 57961533
 dataSources:
   - kind: ethereum/contract
     name: CarbonProjectsAddress  

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -572,8 +572,7 @@ templates:
           handler: handleToucanPuroRetirementReverted
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleCreditTransfer
-      file: ./src/TransferHandler.ts   
-         
+      file: ./src/TransferHandler.ts    
   - name: C3ProjectToken
     kind: ethereum/contract
     network: matic
@@ -622,3 +621,16 @@ templates:
         - event: ExAnteMinted(indexed uint256,indexed uint256,indexed address,uint256)
           handler: handleExAnteMinted
       file: ./src/TransferHandler.ts
+  - name: C3RetirementMetadata
+    kind: file/ipfs
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/RetirementHandler.ts
+      handler: handleC3RetirementMetadata
+      entities:
+        - C3RetireRequest      
+        - C3RetirementMetadata
+      abis:
+        - name: ICRProjectToken
+          file: ../lib/abis/ICRProjectToken.json

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -3,6 +3,11 @@ description: Polygon Carbon
 repository: https://github.com/KlimaDAO/klima-subgraph
 schema:
   file: ./schema.graphql
+features:
+  - grafting
+graft:
+  base: QmYaGZwuyGsCKyPzKLqLrUtVxubJXTFj8953X7Fm1QyUXd
+  block: 57961533
 dataSources:
   - kind: ethereum/contract
     name: CarbonProjectsAddress  
@@ -626,11 +631,12 @@ templates:
     mapping:
       apiVersion: 0.0.7
       language: wasm/assemblyscript
-      file: ./src/RetirementHandler.ts
+      file: ./src/MetadataHandler.ts
       handler: handleC3RetirementMetadata
       entities:
         - C3RetireRequest      
         - C3RetirementMetadata
+        - C3MetadataProject
       abis:
         - name: ICRProjectToken
           file: ../lib/abis/ICRProjectToken.json

--- a/polygon-digital-carbon/utils/ipfs.ts
+++ b/polygon-digital-carbon/utils/ipfs.ts
@@ -1,0 +1,3 @@
+export const extractIpfsHash = (uri: string): string => {
+  return uri.split('ipfs://')[1]
+}


### PR DESCRIPTION
Implementing file data sources for c3 async retirement metadata.

Given the limitations of file data sources the ipfs data cannot be loaded into an on-chain handler.

However, the ipfs retirement data is now available on the `C3RetireRequest` entity, which will eliminate the need for extra ipfs calls in the api with the tokenURI.


Graft test: [Example Query](https://api.studio.thegraph.com/proxy/28985/testing-ground/fds-brain-working-again/graphql?query=query+MyQuery+%7B%0A++retire%28id%3A+%220x91eaab967a195d7b968269ca9d7282bdce65179a03000000%22%29+%7B%0A++++c3RetireRequest+%7B%0A++++++retirementMetadata+%7B%0A++++++++vintage%0A++++++++transferee%0A++++++++reason%0A++++++++projectId%0A++++++++projectAddress%0A++++++++pdf%0A++++++++owner%0A++++++++nftRegistry%0A++++++++image%0A++++++++id%0A++++++++amount%0A++++++++project+%7B%0A++++++++++uri%0A++++++++++registry%0A++++++++++region%0A++++++++++project_type%0A++++++++++project_id%0A++++++++++period_start%0A++++++++++period_end%0A++++++++++name%0A++++++++++methodology%0A++++++++++id%0A++++++++++country%0A++++++++++ac%0A++++++++%7D%0A++++++%7D%0A++++++status%0A++++%7D%0A++%7D%0A%7D)

full sync test (sync started 6/24): https://api.studio.thegraph.com/query/28985/digital-carbon-sandbox/c3-ipfs-full-sync-2