### PR TITLE
[`digital-carbon`] Combine async retire entities

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -33,7 +33,7 @@ enum ProvenanceType {
   DETOKENIZED
 }
 
-enum BridgeStatus {
+enum AsyncRetireStatus {
   FINALIZED
   REQUESTED
   REVERTED
@@ -365,14 +365,15 @@ type Retire @entity {
   "Final provenance record created by this retirement"
   provenance: ProvenanceRecord
 
-  "Bridge status for retirement if applicable"
-  bridgeStatus: BridgeStatus
-
   ### Additional attributes if applicable ###
 
   klimaRetire: KlimaRetire @derivedFrom(field: "retire")
 
-  c3RetireRequest: C3RetireRequest
+  "Async retire status for retirement if applicable"
+  asyncRetireStatus: AsyncRetireStatus
+
+  "Additional data for async retirements. Currently C3 retires, ECO & J-Credit, and puro.earth"
+  asyncRetireRequest: AsyncRetireRequest
 }
 
 type KlimaRetire @entity {
@@ -407,18 +408,6 @@ type ToucanBatch @entity {
   creationTransactionHash: Bytes!
 }
 
-type C3RetireRequest @entity {
-  "Request ID"
-  id: Bytes!
-  index: BigInt!
-  c3OffsetNftIndex: BigInt!
-  status: BridgeStatus!
-  retire: Retire
-  provenance: ProvenanceRecord
-  tokenURI: String!
-  retirementMetadata: C3RetirementMetadata
-}
-
 # C3Project and C3RetirementMetadata are used for file datasources for C3 metadata
 type C3MetadataProject @entity {
   id: ID!
@@ -450,20 +439,29 @@ type C3RetirementMetadata @entity {
   nftRegistry: String
 }
 
-
 # id is always and only safeguard
 type TokenURISafeguard @entity {
   "Token URI"
   id: ID!
-  requestsWithoutURI: [C3RetireRequest!]!
+  requestsWithoutURI: [C3RetireRequestDetails!]!
 }
 
-type ToucanBridgeRequest @entity {
+type AsyncRetireRequest @entity {
   "Request ID"
-  id: ID!
-  status: BridgeStatus!
-  retire: Retire
+  id: Bytes!
+  status: AsyncRetireStatus!
+  retire: Retire!
   provenance: ProvenanceRecord
+  c3RetireRequestDetails: C3RetireRequestDetails
+}
+
+type C3RetireRequestDetails @entity {
+  "Request ID"
+  id: Bytes!
+  index: BigInt!
+  c3OffsetNftIndex: BigInt!
+  tokenURI: String!
+  retirementMetadata: C3RetirementMetadata
 }
 
 ##############################

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -123,22 +123,25 @@ export function saveToucanPuroRetirementRequest(event: RetirementRequested): voi
     event.params.requestId.toString()
   )
 
+
+  let requestId = createAsyncRetireRequestId(event.address, event.params.requestId)
+
+  let request = loadOrCreateAsyncRetireRequest(requestId)
+
   let retire = loadRetire(retireId)
   retire.beneficiaryLocation = event.params.params.beneficiaryLocation
   retire.consumptionCountryCode = event.params.params.consumptionCountryCode
   retire.consumptionPeriodStart = event.params.params.consumptionPeriodStart
   retire.consumptionPeriodEnd = event.params.params.consumptionPeriodEnd
   retire.asyncRetireStatus = AsyncRetireRequestStatus.REQUESTED
+  retire.asyncRetireRequest = requestId
   retire.save()
 
-  let requestId = createAsyncRetireRequestId(event.address, event.params.requestId)
-
-  let request = loadOrCreateAsyncRetireRequest(requestId)
 
   request.retire = retireId
   request.provenance = retire.provenance
-
   request.save()
+
   incrementAccountRetirements(senderAddress)
 }
 

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -299,6 +299,7 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
   c3RetireRequestDetails.index = event.params.index
   c3RetireRequestDetails.save()
 
+  asyncRetireRequest.c3RetireRequestDetails = c3RetireRequestDetails.id
   asyncRetireRequest.save()
 
   retire.asyncRetireRequest = requestId
@@ -362,12 +363,13 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
       retire.save()
 
       asyncRetireRequest.status = AsyncRetireRequestStatus.FINALIZED
-      
     } else if (asyncRetireRequest.status == AsyncRetireRequestStatus.REQUESTED && event.params.success == false) {
       asyncRetireRequest.status = AsyncRetireRequestStatus.REVERTED
     }
   }
   c3RetireRequestDetails.save()
+
+  asyncRetireRequest.c3RetireRequestDetails = c3RetireRequestDetails.id
   asyncRetireRequest.save()
 }
 

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -123,7 +123,6 @@ export function saveToucanPuroRetirementRequest(event: RetirementRequested): voi
     event.params.requestId.toString()
   )
 
-
   let requestId = createAsyncRetireRequestId(event.address, event.params.requestId)
 
   let request = loadOrCreateAsyncRetireRequest(requestId)
@@ -136,7 +135,6 @@ export function saveToucanPuroRetirementRequest(event: RetirementRequested): voi
   retire.asyncRetireStatus = AsyncRetireRequestStatus.REQUESTED
   retire.asyncRetireRequest = requestId
   retire.save()
-
 
   request.retire = retireId
   request.provenance = retire.provenance

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -119,7 +119,8 @@ export function saveToucanPuroRetirementRequest(event: RetirementRequested): voi
     senderAddress,
     event.params.params.retiringEntityString,
     event.block.timestamp,
-    event.transaction.hash
+    event.transaction.hash,
+    event.params.requestId.toString()
   )
 
   let retire = loadRetire(retireId)
@@ -174,7 +175,7 @@ export function handleVCUOMinted(event: VCUOMinted): void {
       senderAddress,
       '',
       event.block.timestamp,
-      event.transaction.hash
+      event.transaction.hash,
     )
 
     incrementAccountRetirements(senderAddress)
@@ -283,7 +284,7 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
     '',
     event.block.timestamp,
     event.transaction.hash,
-    'C3'
+    event.params.index.toString()
   )
 
   let retire = loadRetire(retireId)

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -18,7 +18,7 @@ import { loadRetire, saveRetire } from './utils/Retire'
 import { Bytes, log } from '@graphprotocol/graph-ts'
 import { loadOrCreateC3RetireRequestDetails, loadC3RetireRequestDetails } from './utils/C3'
 import { Token, TokenURISafeguard } from '../generated/schema'
-import { getC3RetireRequestId } from '../utils/getRetirementsContractAddress'
+import { createAsyncRetireRequestId } from '../utils/getRetirementsContractAddress'
 import { AsyncRetireRequestStatus } from '../utils/enums'
 import { loadAsyncRetireRequest, loadOrCreateAsyncRetireRequest } from './utils/AsyncRetireRequest'
 import { C3RetirementMetadata as C3RetirementMetadataTemplate } from '../generated/templates'
@@ -131,8 +131,7 @@ export function saveToucanPuroRetirementRequest(event: RetirementRequested): voi
   retire.asyncRetireStatus = AsyncRetireRequestStatus.REQUESTED
   retire.save()
 
-  let requestIdByteArray = Bytes.fromBigInt(event.params.requestId)
-  let requestId = Bytes.fromByteArray(requestIdByteArray)
+  let requestId = createAsyncRetireRequestId(event.address, event.params.requestId)
 
   let request = loadOrCreateAsyncRetireRequest(requestId)
 
@@ -175,7 +174,7 @@ export function handleVCUOMinted(event: VCUOMinted): void {
       senderAddress,
       '',
       event.block.timestamp,
-      event.transaction.hash,
+      event.transaction.hash
     )
 
     incrementAccountRetirements(senderAddress)
@@ -289,7 +288,7 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
 
   let retire = loadRetire(retireId)
 
-  let requestId = getC3RetireRequestId(event.params.fromToken, event.params.index)
+  let requestId = createAsyncRetireRequestId(event.params.fromToken, event.params.index)
 
   let c3RetireRequestDetails = loadOrCreateC3RetireRequestDetails(requestId)
   c3RetireRequestDetails.index = event.params.index
@@ -314,7 +313,7 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
 
   loadOrCreateAccount(event.transaction.from)
 
-  let requestId = getC3RetireRequestId(event.params.fromToken, event.params.index)
+  let requestId = createAsyncRetireRequestId(event.params.fromToken, event.params.index)
 
   let c3RetireRequestDetails = loadC3RetireRequestDetails(requestId)
   let asyncRetireRequest = loadAsyncRetireRequest(requestId)

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -15,12 +15,12 @@ import { incrementAccountRetirements, loadOrCreateAccount } from './utils/Accoun
 import { loadCarbonCredit, loadOrCreateCarbonCredit } from './utils/CarbonCredit'
 import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { loadRetire, saveRetire } from './utils/Retire'
-import { log } from '@graphprotocol/graph-ts'
-import { loadOrCreateC3RetireRequest, loadC3RetireRequest } from './utils/C3'
+import { Bytes, log } from '@graphprotocol/graph-ts'
+import { loadOrCreateC3RetireRequestDetails, loadC3RetireRequestDetails } from './utils/C3'
 import { Token, TokenURISafeguard } from '../generated/schema'
 import { getC3RetireRequestId } from '../utils/getRetirementsContractAddress'
-import { BridgeStatus } from '../utils/enums'
-import { loadOrCreateToucanBridgeRequest } from './utils/Toucan'
+import { AsyncRetireRequestStatus } from '../utils/enums'
+import { loadAsyncRetireRequest, loadOrCreateAsyncRetireRequest } from './utils/AsyncRetireRequest'
 import { C3RetirementMetadata as C3RetirementMetadataTemplate } from '../generated/templates'
 import { extractIpfsHash } from '../utils/ipfs'
 
@@ -127,14 +127,16 @@ export function saveToucanPuroRetirementRequest(event: RetirementRequested): voi
   retire.consumptionCountryCode = event.params.params.consumptionCountryCode
   retire.consumptionPeriodStart = event.params.params.consumptionPeriodStart
   retire.consumptionPeriodEnd = event.params.params.consumptionPeriodEnd
-  retire.bridgeStatus = 'REQUESTED'
+  retire.asyncRetireStatus = AsyncRetireRequestStatus.REQUESTED
   retire.save()
 
-  let request = loadOrCreateToucanBridgeRequest(event.params.requestId)
+  let requestIdByteArray = Bytes.fromBigInt(event.params.requestId)
+  let requestId = Bytes.fromByteArray(requestIdByteArray)
+
+  let request = loadOrCreateAsyncRetireRequest(requestId)
+
   request.retire = retireId
-  if (retire != null) {
-    request.provenance = retire.provenance
-  }
+  request.provenance = retire.provenance
 
   request.save()
   incrementAccountRetirements(senderAddress)
@@ -287,15 +289,19 @@ export function saveStartAsyncToken(event: StartAsyncToken): void {
   let retire = loadRetire(retireId)
 
   let requestId = getC3RetireRequestId(event.params.fromToken, event.params.index)
-  let request = loadOrCreateC3RetireRequest(requestId)
 
-  request.status = BridgeStatus.REQUESTED
-  request.index = event.params.index
-  request.retire = retireId
-  request.provenance = retire.provenance
-  request.save()
+  let asyncRetireRequest = loadOrCreateAsyncRetireRequest(requestId)
+  asyncRetireRequest.retire = retireId
+  asyncRetireRequest.provenance = retire.provenance
+  asyncRetireRequest.status = AsyncRetireRequestStatus.REQUESTED
 
-  retire.c3RetireRequest = requestId
+  let c3RetireRequestDetails = loadOrCreateC3RetireRequestDetails(requestId)
+  c3RetireRequestDetails.index = event.params.index
+  c3RetireRequestDetails.save()
+
+  asyncRetireRequest.save()
+
+  retire.asyncRetireRequest = requestId
   retire.save()
 
   incrementAccountRetirements(senderAddress)
@@ -307,18 +313,18 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
   loadOrCreateAccount(event.transaction.from)
 
   let requestId = getC3RetireRequestId(event.params.fromToken, event.params.index)
-  let request = loadC3RetireRequest(requestId)
 
-  if (request == null) {
-    log.error('No C3RetireRequest found for retireId: {} hash: {}', [
-      event.transaction.hash.toHexString(),
-    ])
+  let asyncRetireRequest = loadAsyncRetireRequest(requestId)
+  let c3RetireRequestDetails = loadC3RetireRequestDetails(requestId)
+
+  if (c3RetireRequestDetails == null) {
+    log.error('No C3RetireRequest found for retireId: {} hash: {}', [event.transaction.hash.toHexString()])
     return
   } else {
-    if (request.status == BridgeStatus.REQUESTED && event.params.success == true) {
+    if (asyncRetireRequest.status == AsyncRetireRequestStatus.REQUESTED && event.params.success == true) {
       let c3OffsetNftContract = C3OffsetNFT.bind(C3_VERIFIED_CARBON_UNITS_OFFSET)
 
-      request.c3OffsetNftIndex = event.params.nftIndex
+      c3RetireRequestDetails.c3OffsetNftIndex = event.params.nftIndex
 
       let tokenURICall = c3OffsetNftContract.try_tokenURI(event.params.nftIndex)
 
@@ -337,22 +343,32 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           requestsArray.push(requestId)
           safeguard.requestsWithoutURI = requestsArray
           safeguard.save()
-          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
+          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [
+            event.params.nftIndex.toString(),
+          ])
         } else {
-          request.tokenURI = tokenURI
+          c3RetireRequestDetails.tokenURI = tokenURI
           const hash = extractIpfsHash(tokenURI)
 
-          request.retirementMetadata = hash
+          c3RetireRequestDetails.retirementMetadata = hash
           C3RetirementMetadataTemplate.create(hash)
         }
       }
 
-      request.status = BridgeStatus.FINALIZED
-    } else if (request.status == BridgeStatus.REQUESTED && event.params.success == false) {
-      request.status = BridgeStatus.REVERTED
+      // set status on retire as well
+      let retireId: Bytes = asyncRetireRequest.retire
+      let retire = loadRetire(retireId)
+      retire.asyncRetireStatus = AsyncRetireRequestStatus.FINALIZED
+      retire.save()
+
+      asyncRetireRequest.status = AsyncRetireRequestStatus.FINALIZED
+      
+    } else if (asyncRetireRequest.status == AsyncRetireRequestStatus.REQUESTED && event.params.success == false) {
+      asyncRetireRequest.status = AsyncRetireRequestStatus.REVERTED
     }
   }
-  request.save()
+  c3RetireRequestDetails.save()
+  asyncRetireRequest.save()
 }
 
 export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
@@ -368,13 +384,12 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
   /** Target the request with the index that matches the event.params.tokenId
    * With event.params.tokenId, it's theoretically possible to call .list() on the C3OffsetNFT contract to get the project address
    * However the issue is the request cannot be loaded as the request id is project address.concat(with retirement index)
-   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or 
-   * credit contract with any of the event params to retrieve the retirement index  */ 
-
+   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or
+   * credit contract with any of the event params to retrieve the retirement index  */
 
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]
-    let request = loadC3RetireRequest(requestId)
+    let request = loadC3RetireRequestDetails(requestId)
     if (request == null) {
       log.error('handleURIBlockSafeguard request is null {}', [requestId.toHexString()])
       continue

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -103,11 +103,11 @@ export function handleToucanPuroRetirementFinalized(event: RetirementFinalized):
   request.status = AsyncRetireRequestStatus.FINALIZED
   request.save()
 
-  // if (request.retire !== null) {
-  //   let retire = loadRetire(request.retire)
-  //   retire.AsyncRetireRequestStatus = 'FINALIZED'
-  //   retire.save()
-  // }
+  if (request.retire !== null) {
+    let retire = loadRetire(request.retire)
+    retire.asyncRetireStatus = AsyncRetireRequestStatus.FINALIZED
+    retire.save()
+  }
 }
 
 // TODO:

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -33,6 +33,7 @@ import {
 } from '../generated/templates/ToucanPuroCarbonOffsets/ToucanPuroCarbonOffsets'
 import { loadOrCreateAsyncRetireRequest } from './utils/AsyncRetireRequest'
 import { AsyncRetireRequestStatus } from '../utils/enums'
+import { createAsyncRetireRequestId } from '../utils/getRetirementsContractAddress'
 
 export function handleCreditTransfer(event: Transfer): void {
   recordTransfer(
@@ -96,8 +97,8 @@ export function handleToucanPuroRetirementRequested(event: RetirementRequested):
 }
 
 export function handleToucanPuroRetirementFinalized(event: RetirementFinalized): void {
-  let requestIdByteArray = Bytes.fromBigInt(event.params.requestId)
-  let requestId = Bytes.fromByteArray(requestIdByteArray)
+
+  let requestId = createAsyncRetireRequestId(event.address, event.params.requestId)
 
   let request = loadOrCreateAsyncRetireRequest(requestId)
   request.status = AsyncRetireRequestStatus.FINALIZED

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -1,11 +1,5 @@
-import { Address, BigInt, Bytes, ethereum, log, store } from '@graphprotocol/graph-ts'
-import {
-  ICR_MIGRATION_BLOCK,
-  ICR_MIGRATION_HASHES,
-  MCO2_ERC20_CONTRACT,
-  TOUCAN_CROSS_CHAIN_MESSENGER,
-  ZERO_ADDRESS,
-} from '../../lib/utils/Constants'
+import { Address, BigInt, Bytes, store } from '@graphprotocol/graph-ts'
+import { ICR_MIGRATION_BLOCK, ICR_MIGRATION_HASHES, MCO2_ERC20_CONTRACT, ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { Transfer } from '../generated/BCT/ERC20'
 import { loadOrCreateCarbonCredit, updateICRCredit } from './utils/CarbonCredit'
 import { Retired, Retired1 as Retired_1_4_0 } from '../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets'
@@ -37,7 +31,8 @@ import {
   RetirementRequested,
   RetirementFinalized,
 } from '../generated/templates/ToucanPuroCarbonOffsets/ToucanPuroCarbonOffsets'
-import { loadOrCreateToucanBridgeRequest } from './utils/Toucan'
+import { loadOrCreateAsyncRetireRequest } from './utils/AsyncRetireRequest'
+import { AsyncRetireRequestStatus } from '../utils/enums'
 
 export function handleCreditTransfer(event: Transfer): void {
   recordTransfer(
@@ -101,13 +96,16 @@ export function handleToucanPuroRetirementRequested(event: RetirementRequested):
 }
 
 export function handleToucanPuroRetirementFinalized(event: RetirementFinalized): void {
-  let request = loadOrCreateToucanBridgeRequest(event.params.requestId)
-  request.status = 'FINALIZED'
+  let requestIdByteArray = Bytes.fromBigInt(event.params.requestId)
+  let requestId = Bytes.fromByteArray(requestIdByteArray)
+
+  let request = loadOrCreateAsyncRetireRequest(requestId)
+  request.status = AsyncRetireRequestStatus.FINALIZED
   request.save()
 
   // if (request.retire !== null) {
   //   let retire = loadRetire(request.retire)
-  //   retire.bridgeStatus = 'FINALIZED'
+  //   retire.AsyncRetireRequestStatus = 'FINALIZED'
   //   retire.save()
   // }
 }

--- a/polygon-digital-carbon/src/utils/AsyncRetireRequest.ts
+++ b/polygon-digital-carbon/src/utils/AsyncRetireRequest.ts
@@ -1,0 +1,20 @@
+import { Bytes } from '@graphprotocol/graph-ts'
+import { AsyncRetireRequest } from '../../generated/schema'
+import { AsyncRetireRequestStatus } from '../../utils/enums'
+
+export function loadOrCreateAsyncRetireRequest(requestId: Bytes): AsyncRetireRequest {
+  let request = AsyncRetireRequest.load(requestId)
+  if (request == null) {
+    request = new AsyncRetireRequest(requestId)
+    request.retire = new Bytes(0)
+    request.status = AsyncRetireRequestStatus.AWAITING
+    request.save()
+  }
+  return request as AsyncRetireRequest
+}
+
+export function loadAsyncRetireRequest(requestId: Bytes): AsyncRetireRequest {
+  let request = AsyncRetireRequest.load(requestId)
+
+  return request as AsyncRetireRequest
+}

--- a/polygon-digital-carbon/src/utils/C3.ts
+++ b/polygon-digital-carbon/src/utils/C3.ts
@@ -1,13 +1,11 @@
 import { BigInt, Bytes } from '@graphprotocol/graph-ts'
-import { C3RetireRequest } from '../../generated/schema'
-import { BridgeStatus } from '../../utils/enums'
+import { C3RetireRequestDetails } from '../../generated/schema'
 
-export function loadOrCreateC3RetireRequest(requestId: Bytes): C3RetireRequest {
-  let request = C3RetireRequest.load(requestId)
+export function loadOrCreateC3RetireRequestDetails(requestId: Bytes): C3RetireRequestDetails {
+  let request = C3RetireRequestDetails.load(requestId)
 
   if (request == null) {
-    request = new C3RetireRequest(requestId)
-    request.status = BridgeStatus.AWAITING
+    request = new C3RetireRequestDetails(requestId)
     request.index = BigInt.fromI32(0)
     request.c3OffsetNftIndex = BigInt.fromI32(0)
     request.tokenURI = ''
@@ -17,7 +15,7 @@ export function loadOrCreateC3RetireRequest(requestId: Bytes): C3RetireRequest {
   return request
 }
 
-export function loadC3RetireRequest(requestId: Bytes): C3RetireRequest | null {
-  let request = C3RetireRequest.load(requestId)
+export function loadC3RetireRequestDetails(requestId: Bytes): C3RetireRequestDetails | null {
+  let request = C3RetireRequestDetails.load(requestId)
   return request
 }

--- a/polygon-digital-carbon/src/utils/Toucan.ts
+++ b/polygon-digital-carbon/src/utils/Toucan.ts
@@ -1,5 +1,5 @@
 import { BigInt, Bytes } from '@graphprotocol/graph-ts'
-import { ToucanBatch, ToucanBridgeRequest } from '../../generated/schema'
+import { ToucanBatch } from '../../generated/schema'
 
 export function loadOrCreateToucanBatch(batchId: BigInt): ToucanBatch {
   let batch = ToucanBatch.load(batchId.toString())
@@ -12,12 +12,3 @@ export function loadOrCreateToucanBatch(batchId: BigInt): ToucanBatch {
   return batch as ToucanBatch
 }
 
-export function loadOrCreateToucanBridgeRequest(requestId: BigInt): ToucanBridgeRequest {
-  let request = ToucanBridgeRequest.load(requestId.toString())
-  if (request == null) {
-    request = new ToucanBridgeRequest(requestId.toString())
-    request.status = 'REQUESTED'
-    request.save()
-  }
-  return request as ToucanBridgeRequest
-}

--- a/polygon-digital-carbon/utils/enums.ts
+++ b/polygon-digital-carbon/utils/enums.ts
@@ -1,4 +1,4 @@
-export class BridgeStatus {
+export class AsyncRetireRequestStatus {
     static readonly FINALIZED: string = 'FINALIZED';
     static readonly REQUESTED: string = 'REQUESTED';
     static readonly REVERTED: string = 'REVERTED';

--- a/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
+++ b/polygon-digital-carbon/utils/getRetirementsContractAddress.ts
@@ -7,6 +7,6 @@ export function getRetirementsContractAddress(network: string): Address {
     : AMOY_KLIMA_CARBON_RETIREMENTS_CONTRACT
 }
 
-export function getC3RetireRequestId(fromToken: Address, index: BigInt): Bytes {
-  return fromToken.concatI32(index.toI32())
+export function createAsyncRetireRequestId(token: Address, index: BigInt): Bytes {
+  return token.concatI32(index.toI32())
 }


### PR DESCRIPTION
This PR combines the `ToucanBridgeRequest` and `C3RetireRequest` into one entity `AsyncRetireRequest`. 

Any registry specific fields that aren't required for other async requests are saved in their own entity on `AsyncRetireRequest`.