### PR TITLE
[`digital-carbon`] Add `UNSUPPORTED_REGISTRY` as c3 fallback

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -7,6 +7,7 @@ enum Registry {
   ICR
   J_CREDIT
   ECO_REGISTRY
+  UNSUPPORTED_REGISTRY
 }
 
 enum RetireSource {

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -170,6 +170,7 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
   else if (attributes.registry == 'JCS' || attributes.registry == 'JPN') registry = 'J_CREDIT'
   else if (attributes.registry == 'ACR') registry = 'AMERICAN_CARBON_REGISTRY'
   else if (attributes.registry == 'ECO') registry = 'ECO_REGISTRY'
+  else registry = 'UNSUPPORTED_REGISTRY';
 
   let projectID: string
 


### PR DESCRIPTION
In the past tokens from c3 for registries not in the subgraph Registry enum have broken the subgraph sync.

This PR adds a fallback in case c3 issues credits for registries not in the registry enum so that there is no break in production  until the schema is updated with the new registries.