### PR TITLE
[`digital-carbon`] Add ECO projects to lib/

### DIFF
--- a/carbonmark/src/Projects.ts
+++ b/carbonmark/src/Projects.ts
@@ -11144,7 +11144,6 @@ export const PROJECT_INFO: ProjectInfo[] = [
     '0',
     false
   ),
-
   new ProjectInfo(
     '0xa8853ffc5a0aeab7d31631a4b87cb12c0b289c6c',
     'ECO-114',
@@ -11156,7 +11155,6 @@ export const PROJECT_INFO: ProjectInfo[] = [
     '0',
     false
   ),
-
   new ProjectInfo(
     '0x6960ce1d21f63c4971324b5b611c4de29acf980c',
     'PUR-862421',

--- a/lib/utils/EcoRegistryProjectInfo.ts
+++ b/lib/utils/EcoRegistryProjectInfo.ts
@@ -1,0 +1,18 @@
+export const ECO_REGISTRY_PROJECT_INFO = [
+  [
+    '0xa8853ffc5a0aeab7d31631a4b87cb12c0b289c6c',
+    'ECO-114',
+    'PROYECTO REDD+ PAZCÍFICO SUR',
+    'MLU-REDD+',
+    'Forestry',
+    'Colombia',
+  ],
+  [
+    '0x4b69a69a80048e321da1d751f0f9dc39b5d63454',
+    'ECO-22',
+    'Proyecto Conservación ARLEQUÍN REDD+',
+    'MLU-REDD+',
+    'Forestry',
+    'Colombia',
+  ],
+]

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -190,7 +190,7 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
   carbonCredit.save()
 
   project.methodologies = attributes.methodology
-  project.category = project.category ?? MethodologyCategories.getMethodologyCategory(project.methodologies)
+  project.category = project.category != '' ? project.category : MethodologyCategories.getMethodologyCategory(project.methodologies)
   project.region = attributes.region
   project.save()
 

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -190,9 +190,8 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
   carbonCredit.save()
 
   project.methodologies = attributes.methodology
-  project.category = MethodologyCategories.getMethodologyCategory(project.methodologies)
+  project.category = project.category ?? MethodologyCategories.getMethodologyCategory(project.methodologies)
   project.region = attributes.region
-  project.methodologies = attributes.methodology
   project.save()
 
   return carbonCredit

--- a/polygon-digital-carbon/src/utils/CarbonProject.ts
+++ b/polygon-digital-carbon/src/utils/CarbonProject.ts
@@ -42,6 +42,7 @@ export function loadOrCreateCarbonProject(registry: string, projectID: string): 
         if (projectID == ECO_REGISTRY_PROJECT_INFO[i][0]) {
           project.name = ECO_REGISTRY_PROJECT_INFO[i][1]
           project.country = ECO_REGISTRY_PROJECT_INFO[i][2]
+          project.category = ECO_REGISTRY_PROJECT_INFO[i][4]
           break
         }
       }

--- a/polygon-digital-carbon/src/utils/CarbonProject.ts
+++ b/polygon-digital-carbon/src/utils/CarbonProject.ts
@@ -1,3 +1,4 @@
+import { ECO_REGISTRY_PROJECT_INFO } from '../../../lib/utils/EcoRegistryProjectInfo'
 import { PURO_PROJECT_INFO } from '../../../lib/utils/PuroProjectInfo'
 import { VERRA_PROJECT_NAMES } from '../../../lib/utils/VerraProjectInfo'
 
@@ -31,6 +32,16 @@ export function loadOrCreateCarbonProject(registry: string, projectID: string): 
         if (projectID == PURO_PROJECT_INFO[i][0]) {
           project.name = PURO_PROJECT_INFO[i][1]
           project.country = PURO_PROJECT_INFO[i][2]
+          break
+        }
+      }
+    }
+
+    if (registry == 'ECO_REGISTRY') {
+      for (let i = 0; i < ECO_REGISTRY_PROJECT_INFO.length; i++) {
+        if (projectID == ECO_REGISTRY_PROJECT_INFO[i][0]) {
+          project.name = ECO_REGISTRY_PROJECT_INFO[i][1]
+          project.country = ECO_REGISTRY_PROJECT_INFO[i][2]
           break
         }
       }


### PR DESCRIPTION
The on-chain name and category isn't reliable for c3 projects yet. 

This is a temporary fix to add c3 projects for name and category info. Normally this wouldn't matter and would be fetched from the cms, however in the frontend there is still a direct subgraph call where these attributes are needed.