### PR TITLE
[`digital-carbon`] Fix amount handling in c3RetirementMetadata

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -441,7 +441,7 @@ type C3RetirementMetadata @entity {
   reason: String
   projectId: String
   projectAddress: Bytes
-  amount: Int
+  amount: String
   vintage: String
   owner: Bytes
   project: C3MetadataProject

--- a/polygon-digital-carbon/src/MetadataHandler.ts
+++ b/polygon-digital-carbon/src/MetadataHandler.ts
@@ -21,7 +21,7 @@ export function handleC3RetirementMetadata(content: Bytes): void {
     if (reason) c3RetirementMetadata.reason = reason.toString()
     if (projectId) c3RetirementMetadata.projectId = projectId.toString()
     if (projectAddress) c3RetirementMetadata.projectAddress = Bytes.fromHexString(projectAddress.toString())
-    if (amount) c3RetirementMetadata.amount = amount.toBigInt().toI32()
+    if (amount) c3RetirementMetadata.amount = amount.toString()
     if (vintage) c3RetirementMetadata.vintage = vintage.toString()
     if (owner) c3RetirementMetadata.owner = Bytes.fromHexString(owner.toString())
     if (image) c3RetirementMetadata.image = image.toString()


### PR DESCRIPTION
The previous deployment attempted a conversion on `amount` that failed on the decimal value (0.001) which was passed in the most recent retirement. Originally eco was supposed to be whole tonne retirements only which is where the break entered.

In this PR amount is just handled as a string to account for all cases.