### PR TITLE
[`digital-carbon`] Remove C3RetirementMetadata

### DIFF
--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -21,7 +21,6 @@ import { Token, TokenURISafeguard } from '../generated/schema'
 import { getC3RetireRequestId } from '../utils/getRetirementsContractAddress'
 import { BridgeStatus } from '../utils/enums'
 import { loadOrCreateToucanBridgeRequest } from './utils/Toucan'
-import { C3RetirementMetadata as C3RetirementMetadataTemplate } from '../generated/templates'
 import { extractIpfsHash } from '../utils/ipfs'
 
 export function saveToucanRetirement(event: Retired): void {
@@ -310,9 +309,7 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
   let request = loadC3RetireRequest(requestId)
 
   if (request == null) {
-    log.error('No C3RetireRequest found for retireId: {} hash: {}', [
-      event.transaction.hash.toHexString(),
-    ])
+    log.error('No C3RetireRequest found for retireId: {} hash: {}', [event.transaction.hash.toHexString()])
     return
   } else {
     if (request.status == BridgeStatus.REQUESTED && event.params.success == true) {
@@ -337,13 +334,14 @@ export function completeC3RetireRequest(event: EndAsyncToken): void {
           requestsArray.push(requestId)
           safeguard.requestsWithoutURI = requestsArray
           safeguard.save()
-          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [event.params.nftIndex.toString()])
+          log.error('Initial attempt to retrieve tokenURI is null or empty for nft index {}', [
+            event.params.nftIndex.toString(),
+          ])
         } else {
           request.tokenURI = tokenURI
           const hash = extractIpfsHash(tokenURI)
 
           request.retirementMetadata = hash
-          C3RetirementMetadataTemplate.create(hash)
         }
       }
 
@@ -368,9 +366,8 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
   /** Target the request with the index that matches the event.params.tokenId
    * With event.params.tokenId, it's theoretically possible to call .list() on the C3OffsetNFT contract to get the project address
    * However the issue is the request cannot be loaded as the request id is project address.concat(with retirement index)
-   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or 
-   * credit contract with any of the event params to retrieve the retirement index  */ 
-
+   * The retirement index is not available in this event. There is currently no way to call the C3OffsetNFT or
+   * credit contract with any of the event params to retrieve the retirement index  */
 
   for (let i = 0; i < requestsArray.length; i++) {
     let requestId = requestsArray[i]
@@ -387,7 +384,6 @@ export function handleVCUOMetaDataUpdated(event: VCUOMetaDataUpdated): void {
       const hash = extractIpfsHash(tokenURI)
 
       request.retirementMetadata = hash
-      C3RetirementMetadataTemplate.create(hash)
 
       request.save()
     }

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -621,17 +621,3 @@ templates:
         - event: ExAnteMinted(indexed uint256,indexed uint256,indexed address,uint256)
           handler: handleExAnteMinted
       file: ./src/TransferHandler.ts
-  - name: C3RetirementMetadata
-    kind: file/ipfs
-    mapping:
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      file: ./src/MetadataHandler.ts
-      handler: handleC3RetirementMetadata
-      entities:
-        - C3RetireRequest      
-        - C3RetirementMetadata
-        - C3MetadataProject
-      abis:
-        - name: ICRProjectToken
-          file: ../lib/abis/ICRProjectToken.json

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -621,17 +621,3 @@ templates:
         - event: ExAnteMinted(indexed uint256,indexed uint256,indexed address,uint256)
           handler: handleExAnteMinted
       file: ./src/TransferHandler.ts
-  - name: C3RetirementMetadata
-    kind: file/ipfs
-    mapping:
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      file: ./src/MetadataHandler.ts
-      handler: handleC3RetirementMetadata
-      entities:
-        - C3RetireRequest      
-        - C3RetirementMetadata
-        - C3MetadataProject
-      abis:
-        - name: ICRProjectToken
-          file: ../lib/abis/ICRProjectToken.json


### PR DESCRIPTION
Parsing ipfs data has been problematic and led to broken syncs. This PR removes it to reenable syncs.

Possible fix in this PR: https://github.com/KlimaDAO/klima-subgraph/pull/182

waiting on test deployment