### PR TITLE
[`digital-carbon`] Create `registryRetirementTokenId` field and save ICR registry ID

### DIFF
--- a/polygon-digital-carbon/package.json
+++ b/polygon-digital-carbon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polygon-digital-carbon",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "repository": "https://github.com/KlimaDAO/klima-subgraphs/polygon-carbon",
   "license": "MIT",
   "scripts": {

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -330,6 +330,10 @@ export function saveICRRetirement(event: RetiredVintage): void {
     event.params.data.toString()
   )
 
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
+  retire.retirementTokenId = event.params.nftTokenId
+  retire.save()
+
   incrementAccountRetirements(senderAddress)
 }
 

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -315,7 +315,7 @@ export function saveICRRetirement(event: RetiredVintage): void {
   )
 
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
-  retire.retirementTokenId = event.params.nftTokenId
+  retire.registryRetirementTokenId = event.params.nftTokenId
   retire.save()
 
   incrementAccountRetirements(senderAddress)

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -314,6 +314,10 @@ export function saveICRRetirement(event: RetiredVintage): void {
     event.params.data.toString()
   )
 
+  let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
+  retire.retirementTokenId = event.params.nftTokenId
+  retire.save()
+
   incrementAccountRetirements(senderAddress)
 }
 

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -315,7 +315,7 @@ export function saveICRRetirement(event: RetiredVintage): void {
   )
 
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
-  retire.registryRetirementTokenId = event.params.nftTokenId
+  retire.retirementTokenId = event.params.nftTokenId
   retire.save()
 
   incrementAccountRetirements(senderAddress)

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -331,7 +331,7 @@ export function saveICRRetirement(event: RetiredVintage): void {
   )
 
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
-  retire.registryRetirementTokenId = event.params.nftTokenId
+  retire.retirementTokenId = event.params.nftTokenId
   retire.save()
 
   incrementAccountRetirements(senderAddress)

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -331,7 +331,7 @@ export function saveICRRetirement(event: RetiredVintage): void {
   )
 
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
-  retire.retirementTokenId = event.params.nftTokenId
+  retire.registryRetirementTokenId = event.params.nftTokenId
   retire.save()
 
   incrementAccountRetirements(senderAddress)


### PR DESCRIPTION
Puro, ICR and C3 assign a unique retirement token id (named differently for each registry) on retirement.

For ICR, this retirement token id is needed to create a url to the retirement certificate i.e. `/{retirementTokenId}-{tokenAddress}`.