### PR TITLE
[`digital-carbon`] Add batchSuffix for J-credit

### DIFF
--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -234,6 +234,9 @@ type CarbonCredit @entity {
   "Last batch ID that was fractionalized if applicable"
   lastBatchId: BigInt!
 
+  "Two digit credit identifier for J-credits"
+  batchSuffix: String
+
   # Puro specific fields
   "Puro NFT token ID linked to Puro batch"
   puroBatchTokenId: BigInt

--- a/polygon-digital-carbon/src/utils/CarbonCredit.ts
+++ b/polygon-digital-carbon/src/utils/CarbonCredit.ts
@@ -177,6 +177,8 @@ function updateC3Call(tokenAddress: Address, carbonCredit: CarbonCredit): Carbon
    * the vintage and do not relate to the projectId itself */
   if (attributes.registry == 'JCS' || attributes.registry == 'JPN') {
     projectID = attributes.project_id.slice(0, attributes.project_id.length - 2)
+    let batchSuffix = attributes.project_id.slice(-2)
+    carbonCredit.batchSuffix = batchSuffix
   } else {
     projectID = attributes.project_id
   }


### PR DESCRIPTION
Adding a field for `batchSuffix` to the schema and populating it only for J-credits.

While it'd be possible to add `credit.creditId` field, different registries would require different `creditId` constructions:

JCS: JCS + (`registryProjectId`+`batchSuffix`) + `vintage`
ICR: ICR + `registryProjectId` + `vintage` + `tokenId`
Verra: `registry` + `registryProjectId` + `vintage` i.e. current format

Therefore the Credit class would still be needed to parse the different constructions. It's more straightforward at this stage to just add the batchSuffix which the Credit class already handles.

Although the JCS suffix is named batchId in the Credit class, it is named batchSuffix here to not confuse with batch token(*) ids.
