### PR TITLE
Github Actions Deployment: Alchemy Hosted Service

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,6 +74,9 @@ jobs:
           fi
         env:
           REF: ${{ github.ref }}
-      - name: Deploy Subgraph
+      - name: Deploy Subgraph to Studio
         run: ../node_modules/.bin/graph deploy --studio --deploy-key ${{ secrets.SUBGRAPH_STUDIO_DEPLOY_KEY }} ${{ steps.staging_or_not.outputs.subgraph }} --version-label ${{ steps.staging_or_not.outputs.short_sha }}
+        working-directory: '${{ matrix.value }}'
+      - name: Deploy Subgraph to Alchemy Hosted Service
+        run: ../node_modules/.bin/graph deploy ${{ matrix.value }} --deploy-key ${{ secrets.SUBGRAPH_ALCHEMY_HOSTED_SERVICE_DEPLOY_KEY }} ${{ steps.staging_or_not.outputs.subgraph }} --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --version-label ${{ steps.staging_or_not.outputs.short_sha }}
         working-directory: '${{ matrix.value }}'


### PR DESCRIPTION
Adds an action to simultaneously deploy to both the decentralized network and the alchemy hosted service on a merge to main.