### PR TITLE
[`polygon-bridged-carbon`] Add CCO2 token contract address

### DIFF
--- a/polygon-bridged-carbon/src/utils/Constants.ts
+++ b/polygon-bridged-carbon/src/utils/Constants.ts
@@ -9,6 +9,8 @@ export const UBO_TOKEN: string = 'UBO'
 export const UBO_ERC20_CONTRACT: string = '0x2b3ecb0991af0498ece9135bcd04013d7993110c'
 export const NBO_TOKEN: string = 'NBO'
 export const NBO_ERC20_CONTRACT: string = '0x6bca3b77c1909ce1a4ba1a20d1103bde8d222e48'
+export const CCO2_TOKEN: string = 'CCO2'
+export const CCO2_ERC20_CONTRACT: string = '0x82b37070e43c1ba0ea9e2283285b674ef7f1d4e2'
 
 // Klima Retirement Contracts
 export const KLIMA_CARBON_RETIREMENTS_CONTRACT = '0xac298cd34559b9acfaedea8344a977eceff1c0fd'

--- a/polygon-bridged-carbon/src/utils/Token.ts
+++ b/polygon-bridged-carbon/src/utils/Token.ts
@@ -17,6 +17,9 @@ export function getTokenFromPoolAddress(address: Address): string {
   if (address.equals(Address.fromHexString(constants.NBO_ERC20_CONTRACT))) {
     return constants.NBO_TOKEN
   }
+  if (address.equals(Address.fromHexString(constants.CCO2_ERC20_CONTRACT))) {
+    return constants.CCO2_TOKEN
+  }
 
   if (address.equals(Address.fromString('0x0000000000000000000000000000000000000000'))) {
     // Zero address indicates credit was not from a pool, so set to empty string

--- a/polygon-bridged-carbon/src/utils/pool_token/PoolTokenFactory.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/PoolTokenFactory.ts
@@ -7,6 +7,7 @@ import { MCO2 } from './impl/MCO2'
 import { NBO } from './impl/NBO'
 import { NCT } from './impl/NCT'
 import { UBO } from './impl/UBO'
+import { CCO2 } from './impl/CCO2'
 
 export class PoolTokenFactory {
   constructor() {}
@@ -26,6 +27,9 @@ export class PoolTokenFactory {
     }
     if (address.equals(Address.fromHexString(constants.NBO_ERC20_CONTRACT))) {
       return new NBO(address)
+    }
+    if (address.equals(Address.fromHexString(constants.CCO2_ERC20_CONTRACT))) {
+      return new CCO2(address)
     }
 
     throw new Error('[Carbon Factory] Failed to get Carbon Token for address: ' + address.toHexString())

--- a/polygon-bridged-carbon/src/utils/pool_token/impl/CCO2.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/impl/CCO2.ts
@@ -1,0 +1,49 @@
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
+import { ERC20 } from '../../../../generated/ToucanFactory/ERC20'
+import { CarbonMetric } from '../../../../generated/schema'
+import { IPoolToken } from '../IPoolToken'
+import * as constants from '../../Constants'
+import { toDecimal } from '../../../../../lib/utils/Decimals'
+
+export class CCO2 implements IPoolToken {
+  private contractAddress: Address
+
+  constructor(contractAddress: Address) {
+    this.contractAddress = contractAddress
+  }
+
+  getDecimals(): number {
+    return 18
+  }
+
+  returnUpdatedSupplyMetrics(carbonMetrics: CarbonMetric): CarbonMetric {
+    const oldSupply = carbonMetrics.mco2Supply
+    const newSupplyRaw = ERC20.bind(this.contractAddress).totalSupply()
+    const newSupply = toDecimal(newSupplyRaw, this.getDecimals())
+
+    const deltaSupply = newSupply.minus(oldSupply)
+    carbonMetrics.mco2Supply = newSupply
+    carbonMetrics.totalCarbonSupply = carbonMetrics.totalCarbonSupply.plus(deltaSupply)
+
+    return carbonMetrics
+  }
+
+  returnUpdatedCrosschainSupplyMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+    throw new Error('Method not implemented.')
+  }
+
+  returnUpdatedKlimaRetirementMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+    const oldKlimaRetired = carbonMetrics.mco2KlimaRetired
+    const newKlimaRetired = carbonMetrics.mco2KlimaRetired.plus(toDecimal(amount, this.getDecimals()))
+
+    const delta = newKlimaRetired.minus(oldKlimaRetired)
+    carbonMetrics.mco2KlimaRetired = newKlimaRetired
+    carbonMetrics.totalKlimaRetirements = carbonMetrics.totalKlimaRetirements.plus(delta)
+
+    return carbonMetrics
+  }
+
+  returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+    throw new Error('MCO2 is not redeemable')
+  }
+}


### PR DESCRIPTION
The absence of cco2 is breaking the sync as the subgraph is indexing the CarbonRetired event but doesn't have the cco2 token address available.