### PR TITLE
[`digital-carbon`] Remove origination for products (added cco2)

### DIFF
--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -244,7 +244,7 @@ function recordTransfer(
 
       saveBridge(hash, logIndex, tokenAddress, to, amount, timestamp)
 
-      if (tokenAddress != MCO2_ERC20_CONTRACT) {
+      if (tokenAddress != MCO2_ERC20_CONTRACT && tokenAddress != CCO2_ERC20_CONTRACT) {
         recordProvenance(hash, tokenAddress, tokenId, from, to, 'ORIGINATION', amount, timestamp)
 
         credit.provenanceCount += 1


### PR DESCRIPTION
Following the mco2 pattern, this PR disables origination for cco2. Omitted during the original implementation.