### PR TITLE
[`GHA`] Added -d flag for ci.yaml tests and increase node -v to 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install dependencies
         run: yarn --immutable
         working-directory: '${{ matrix.value }}'
@@ -39,22 +39,22 @@ jobs:
       # https://github.com/marketplace/actions/check-uncommitted-changes
       - name: Prepare Manifest
         if: matrix.value == 'polygon-digital-carbon' || matrix.value == 'carbonmark'
-        run: npm run prepare-matic
+        run: yarn prepare-matic
         working-directory: '${{ matrix.value }}'
       - name: Generate Subgraph Code
-        run: npm run codegen
+        run: yarn codegen
         working-directory: '${{ matrix.value }}'
       - name: Check for uncommitted changes
         id: check-changes
         uses: mskri/check-uncommitted-changes-action@v1.0.1
       - name: Evaluate if there are changes
         if: steps.check-changes.outputs.outcome == failure()
-        run: echo "There are uncommitted changes - execute 'npm run codegen' locally and commit the generated files!"
+        run: echo "There are uncommitted changes - execute 'yarn codegen' locally and commit the generated files!"
         
       - name: Build Subgraph
-        run: npm run build
+        run: yarn build
         working-directory: '${{ matrix.value }}'
       - name: Run Tests
         if: matrix.value == 'polygon-digital-carbon'
-        run: npm run test -d
+        run: yarn test -d
         working-directory: '${{ matrix.value }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,5 +56,5 @@ jobs:
         working-directory: '${{ matrix.value }}'
       - name: Run Tests
         if: matrix.value == 'polygon-digital-carbon'
-        run: npm run test
+        run: npm run test -d
         working-directory: '${{ matrix.value }}'


### PR DESCRIPTION
## 📄 Description

Matchstick does not run in linux; we need to add the -d flag so the tests will run in docker in the gha.

Also required a bump to node v18 in ci.yaml to enable the docker flag.

deply and dev-deploy are still using 16, for consistency those should be increased as well.

<!--
Provide a concise description of the changes introduced by this PR.
-->

## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->


## ✅ Checklist


- [ ] Matchstick test included (if applicable).
- [ ] Version incremented in package.json of the applicable subgraph(s)
- [ ] All changes are reflected in the changelog of this PR for the applicable subgraph(s)

## ℹ️ Additional Information

<!--
Provide any additional information or context that may be relevant to this PR.
-->

