### PR TITLE
[`GHA`] Only deploy to Alchemy on a main merge

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -252,7 +252,7 @@ jobs:
           ../node_modules/.bin/graph deploy --studio --deploy-key ${{ secrets.SUBGRAPH_STUDIO_DEPLOY_KEY }} "${{ steps.staging_or_not.outputs.subgraph }}" --version-label "$VERSION_LABEL"
         working-directory: '${{ matrix.value }}'
       - name: Deploy Subgraph to Alchemy Hosted Service
-        if: ${{ (matrix.value == 'carbonmark' || matrix.value == 'polygon-digital-carbon' || matrix.value == 'pairs' || matrix.value == 'ethereum-bridged-carbon') && steps.compare_versions.outputs.should_deploy == 'true' }}
+        if: ${{ (matrix.value == 'carbonmark' || matrix.value == 'polygon-digital-carbon' || matrix.value == 'pairs' || matrix.value == 'ethereum-bridged-carbon') && env.IS_MAIN == 'true' && steps.compare_versions.outputs.should_deploy == 'true' }}
         run: |
           VERSION_LABEL="${{ steps.compare_versions.outputs.new_published_version }}"
 


### PR DESCRIPTION
## 📄 Description

<!--
Provide a concise description of the changes introduced by this PR.
-->

We should only deploy to alchemy for a main merge to avoid bloating the alchemy entity count ($).

## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->

chore: only alchemy deployments from main merge


## ✅ Checklist


- [ ] Matchstick test included (if applicable).
- [ ] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)


