### PR TITLE
[`gha`] add `ALL_PERMISSIONS_TOKEN` for gha commits

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -181,6 +181,9 @@ jobs:
             echo "Pulling latest changes for branch: $BRANCH_NAME"
             git pull --rebase origin $BRANCH_NAME
 
+            echo "Setting remote URL with all permissions token"
+            git remote set-url origin https://${{ secrets.ALL_PERMISSIONS_TOKEN }}@github.com/${{ github.repository }}.git
+
             echo "Pushing to branch: $BRANCH_NAME"
             git push origin $BRANCH_NAME
           fi
@@ -196,6 +199,18 @@ jobs:
           echo "Tags after creation:"
           git fetch --tags
           git tag --list | grep "${{ matrix.value }}-v"
+
+          if [[ "${GITHUB_REF}" == "refs/heads/"* ]]; then
+            BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          elif [[ "${GITHUB_REF}" == "refs/pull/"* ]]; then
+            BRANCH_NAME=${GITHUB_HEAD_REF}
+          else
+            echo "Unsupported GITHUB_REF format: ${GITHUB_REF}"
+            exit 1
+          fi
+
+          echo "Setting remote URL with all permissions token"
+          git remote set-url origin https://${{ secrets.ALL_PERMISSIONS_TOKEN }}@github.com/${{ github.repository }}.git
 
           git push origin $BRANCH_NAME --tags
         working-directory: '${{ matrix.value }}'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -182,7 +182,7 @@ jobs:
             git pull --rebase origin $BRANCH_NAME
 
             echo "Setting remote URL with all permissions token"
-            git remote set-url origin https://${{ secrets.ALL_PERMISSIONS_TOKEN }}@github.com/${{ github.repository }}.git
+            git remote set-url origin https://${{ secrets.GH_ACCE }}@github.com/${{ github.repository }}.git
 
             echo "Pushing to branch: $BRANCH_NAME"
             git push origin $BRANCH_NAME
@@ -210,7 +210,7 @@ jobs:
           fi
 
           echo "Setting remote URL with all permissions token"
-          git remote set-url origin https://${{ secrets.ALL_PERMISSIONS_TOKEN }}@github.com/${{ github.repository }}.git
+          git remote set-url origin https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
 
           git push origin $BRANCH_NAME --tags
         working-directory: '${{ matrix.value }}'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -182,7 +182,7 @@ jobs:
             git pull --rebase origin $BRANCH_NAME
 
             echo "Setting remote URL with all permissions token"
-            git remote set-url origin https://${{ secrets.GH_ACCE }}@github.com/${{ github.repository }}.git
+            git remote set-url origin https://${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}.git
 
             echo "Pushing to branch: $BRANCH_NAME"
             git push origin $BRANCH_NAME


### PR DESCRIPTION
## 📄 Description

added a new token (which needs to be added to gh) ALL_PERMISSIONS_TOKEN that will allow the gha commits and tags to occur.

<!--
Provide a concise description of the changes introduced by this PR.
-->

## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->

chore: add ALL_PERMISSIONS_TOKEN


## ✅ Checklist


- [x] Matchstick test included (if applicable).
- [x] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)
- [x] If modifying `polygon-digital-carbon` or `carbonmark` subgraphs, MAKE SURE TO MODIFY `subgraph.template.yaml` (NOT `subgraph.yaml` DIRECTLY!)
  - If modifying `subgraph.template.yaml`, also make sure to run `npm run prepare-matic` locally and commit the resulting rendered `subgraph.yaml`

## ℹ️ Additional Information

<!--
Provide any additional information or context that may be relevant to this PR.
-->

