### PR TITLE
feat: add Reserve to pair entity

### DIFF
--- a/pairs/package.json
+++ b/pairs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klimadao-pairs",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "codegen": "graph codegen",

--- a/pairs/schema.graphql
+++ b/pairs/schema.graphql
@@ -8,6 +8,11 @@ type Pair @entity {
   totalvolume: BigDecimal!
   lastupdate: String!
   swaps: [Swap!]! @derivedFrom(field: "pair")
+  reserve0: BigDecimal!
+  reserve1: BigDecimal!
+  reserve0Raw: BigInt!
+  reserve1Raw: BigInt!
+  reservesLastUpdate: String!
 }
 
 type Token @entity {

--- a/pairs/src/MCO2Pair.ts
+++ b/pairs/src/MCO2Pair.ts
@@ -38,6 +38,11 @@ export function getCreatePair(address: Address): Pair {
     pair.totalvolume = BigDecimalZero
     pair.totalklimaearnedfees = BigDecimalZero
     pair.lastupdate = ''
+    pair.reserve0 = BigDecimalZero
+    pair.reserve1 = BigDecimalZero
+    pair.reserve0Raw = BigIntZero
+    pair.reserve1Raw = BigIntZero
+    pair.reservesLastUpdate = ''
     pair.save()
   }
 
@@ -144,5 +149,13 @@ export function handleSwap(event: SwapEvent): void {
   pair.totalvolume = pair.totalvolume.plus(swap.volume)
   pair.totalklimaearnedfees = pair.totalklimaearnedfees.plus(swap.klimaearnedfees)
   pair.lastupdate = hour_timestamp
+  
+  let reserves = contract.getReserves()
+  pair.reserve0 = toUnits(reserves.value0, token0_decimals)
+  pair.reserve1 = toUnits(reserves.value1, token1_decimals)
+  pair.reserve0Raw = reserves.value0
+  pair.reserve1Raw = reserves.value1
+  pair.reservesLastUpdate = hour_timestamp
+  
   pair.save()
 }

--- a/pairs/src/Pair.ts
+++ b/pairs/src/Pair.ts
@@ -62,6 +62,11 @@ export function getCreatePair(address: Address): Pair {
     pair.totalvolume = BigDecimalZero
     pair.totalklimaearnedfees = BigDecimalZero
     pair.lastupdate = ''
+    pair.reserve0 = BigDecimalZero
+    pair.reserve1 = BigDecimalZero
+    pair.reserve0Raw = BigIntZero
+    pair.reserve1Raw = BigIntZero
+    pair.reservesLastUpdate = ''
     pair.save()
   }
 
@@ -284,6 +289,14 @@ export function handleSwap(event: SwapEvent): void {
     pair.totalvolume = pair.totalvolume.plus(swap.volume)
     pair.totalklimaearnedfees = pair.totalklimaearnedfees.plus(swap.klimaearnedfees)
     pair.lastupdate = hour_timestamp
+    
+    let reserves = contract.getReserves()
+    pair.reserve0 = toUnits(reserves.value0, token0_decimals)
+    pair.reserve1 = toUnits(reserves.value1, token1_decimals)
+    pair.reserve0Raw = reserves.value0
+    pair.reserve1Raw = reserves.value1
+    pair.reservesLastUpdate = hour_timestamp
+    
     pair.save()
   }
   if (event.address == KLIMA_USDC_PAIR) {
@@ -364,6 +377,14 @@ export function handleSwap(event: SwapEvent): void {
     pair.totalvolume = pair.totalvolume.plus(swap.volume)
     pair.totalklimaearnedfees = pair.totalklimaearnedfees.plus(swap.klimaearnedfees)
     pair.lastupdate = hour_timestamp
+    
+    let reserves = contract.getReserves()
+    pair.reserve0 = toUnits(reserves.value0, token0_decimals)
+    pair.reserve1 = toUnits(reserves.value1, token1_decimals)
+    pair.reserve0Raw = reserves.value0
+    pair.reserve1Raw = reserves.value1
+    pair.reservesLastUpdate = hour_timestamp
+    
     pair.save()
   }
 }

--- a/pairs/src/TridentPair.ts
+++ b/pairs/src/TridentPair.ts
@@ -11,7 +11,7 @@ import { Pair as PairContract } from '../generated/KLIMA_USDC/Pair'
 import { Swap as SwapEvent, TridentPair as TridentPairContract } from '../generated/KLIMA_UBO/TridentPair'
 import { ERC20 as ERC20Contract } from '../generated/KLIMA_USDC/ERC20'
 import { Address } from '@graphprotocol/graph-ts'
-import { BigDecimalZero } from './utils/utils'
+import { BigDecimalZero, BigIntZero } from './utils/utils'
 import { hourTimestamp } from '../../lib/utils/Dates'
 import { PriceUtil } from '../../lib/utils/Price'
 
@@ -45,6 +45,11 @@ export function getCreatePair(address: Address): Pair {
     pair.totalvolume = BigDecimalZero
     pair.totalklimaearnedfees = BigDecimalZero
     pair.lastupdate = ''
+    pair.reserve0 = BigDecimalZero
+    pair.reserve1 = BigDecimalZero
+    pair.reserve0Raw = BigIntZero
+    pair.reserve1Raw = BigIntZero
+    pair.reservesLastUpdate = ''
     pair.save()
   }
 
@@ -178,5 +183,13 @@ export function handleSwap(event: SwapEvent): void {
   pair.totalvolume = pair.totalvolume.plus(swap.volume)
   pair.totalklimaearnedfees = pair.totalklimaearnedfees.plus(swap.klimaearnedfees)
   pair.lastupdate = hour_timestamp
+  
+  let reserves = contract.getReserves()
+  pair.reserve0 = toUnits(reserves.value0, token0_decimals)
+  pair.reserve1 = toUnits(reserves.value1, token1_decimals)
+  pair.reserve0Raw = reserves.value0
+  pair.reserve1Raw = reserves.value1
+  pair.reservesLastUpdate = hour_timestamp
+  
   pair.save()
 }

--- a/pairs/tests/swaps.test.ts
+++ b/pairs/tests/swaps.test.ts
@@ -57,6 +57,14 @@ describe('handleSwap', () => {
     // Assert that the pair price is updated correctly
     assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'currentprice', '0.01846581475982910603740163507456394')
     assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'currentpricepertonne', '18.46581475982910603740163507456394')
+    
+    // Assert that the reserve fields are updated correctly
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve0', '0.000023211174326211')
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve1', '2518999568.458520093807838')
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve0Raw', '23211174326211')
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve1Raw', '2518999568458520093807838')
+    // reservesLastUpdate should be set to hour timestamp
+    assert.assertNotNull(assert.loadField('Pair', KLIMA_CCO2_PAIR.toHex(), 'reservesLastUpdate'))
   })
 
   test('KLIMA_CCO2_PAIR:Subsequent swap updates pair price correctly', () => {
@@ -73,6 +81,14 @@ describe('handleSwap', () => {
     // Assert that the pair price is updated correctly
     assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'currentprice', '0.004616453689957276509350408768640985')
     assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'currentpricepertonne', '4.616453689957276509350408768640985')
+    
+    // Assert that the reserve fields are updated correctly
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve0', '0.000023211174326211')
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve1', '2518999568.458520093807838')
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve0Raw', '23211174326211')
+    assert.fieldEquals('Pair', KLIMA_CCO2_PAIR.toHex(), 'reserve1Raw', '2518999568458520093807838')
+    // reservesLastUpdate should be set to hour timestamp
+    assert.assertNotNull(assert.loadField('Pair', KLIMA_CCO2_PAIR.toHex(), 'reservesLastUpdate'))
   })
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -90,6 +106,14 @@ describe('handleSwap', () => {
 
     // should equal current spot price from getReserves
     assert.fieldEquals('Pair', NCT_USDC_PAIR.toHex(), 'currentprice', '0.4427864244831998538451559952378756')
+    
+    // Assert that the reserve fields are updated correctly
+    assert.fieldEquals('Pair', NCT_USDC_PAIR.toHex(), 'reserve0', '54896.292369')
+    assert.fieldEquals('Pair', NCT_USDC_PAIR.toHex(), 'reserve1', '123979167.683545067983988')
+    assert.fieldEquals('Pair', NCT_USDC_PAIR.toHex(), 'reserve0Raw', '54896292369')
+    assert.fieldEquals('Pair', NCT_USDC_PAIR.toHex(), 'reserve1Raw', '123979167683545067983988')
+    // reservesLastUpdate should be set to hour timestamp
+    assert.assertNotNull(assert.loadField('Pair', NCT_USDC_PAIR.toHex(), 'reservesLastUpdate'))
   })
 
   afterEach(() => {

--- a/pairs/version.json
+++ b/pairs/version.json
@@ -1,1 +1,1 @@
-{"schemaVersion": "1.0.8", "publishedVersion": "1.0.8"}
+{"schemaVersion": "1.1.0", "publishedVersion": "1.1.0"}


### PR DESCRIPTION
# Pull Request Template

## 📄 Description

We need to reference LP Reserves in our Carbonmark applications to more accurately display available supply.

## 📝 Changelog
- `feat: add reserves fields to the Pair entity`

## ✅ Checklist
- [x] Matchstick test included (if applicable).
- [x] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)
- [x] If modifying `polygon-digital-carbon` or `carbonmark` subgraphs, MAKE SURE TO MODIFY `subgraph.template.yaml` (NOT `subgraph.yaml` DIRECTLY!)
  - If modifying `subgraph.template.yaml`, also make sure to run `npm run prepare-matic` locally and commit the resulting rendered `subgraph.yaml`
