### PR TITLE
[`Carbonmark`] Intermediate `ProjectByToken` entity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,6 @@ jobs:
       - name: Run Tests
         if: matrix.subgraph == 'polygon-digital-carbon' || matrix.subgraph == 'carbonmark' || matrix.subgraph == 'pairs'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: npm run test -d
         working-directory: '${{ matrix.subgraph }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,6 @@ jobs:
       - name: Run Tests
         if: matrix.subgraph == 'polygon-digital-carbon' || matrix.subgraph == 'carbonmark' || matrix.subgraph == 'pairs'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: npm run test -d
         working-directory: '${{ matrix.subgraph }}'

--- a/carbonmark/package.json
+++ b/carbonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonmark",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "repository": "https://github.com/KlimaDAO/klima-subgraphs/carbonmark",
   "license": "MIT",
   "scripts": {
@@ -22,12 +22,15 @@
     "deploy-args": "graph deploy --ipfs $npm_config_ipfs --node $npm_config_node carbonmark",
     "deploy-version": "graph deploy --ipfs $npm_config_ipfs --node $npm_config_node --version-label $npm_config_label carbonmark",
     "deploy-staging": "graph deploy --ipfs https://api.staging.thegraph.com/ipfs/ --node https://api.staging.thegraph.com/deploy/ carbonmark",
-    "deploy-hosted": "graph deploy --product hosted-service $npm_config_path",
+    "create-local": "graph create --node http://localhost:8020/ carbonmark",
+    "remove-local": "graph remove --node http://localhost:8020/ carbonmark",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 carbonmark",
     "deploy": "npm run prepare-local && npm run codegen && npm run build && npm run graph:remove && npm run graph:create && npm run graph:deploy",
     "set-version": "ts-node ../version-control/set-version.ts",
     "version:patch": "npm version patch",
     "version:minor": "npm version minor",
-    "version:major": "npm version major"
+    "version:major": "npm version major",
+    "local-send": "npm run remove-local && npm run create-local && npm run prepare-local && npm run codegen && npm run build && npm run deploy-local"
   },
   "devDependencies": {
     "@types/node": "20.12.7",

--- a/carbonmark/schema.graphql
+++ b/carbonmark/schema.graphql
@@ -23,7 +23,7 @@ type User @entity {
 }
 
 type Project @entity {
- "Credit ID ({projectId}-{vintage})"
+  "Credit ID ({projectId}-{vintage})"
   id: ID!
 
   "Project ID ({registry Enum String}-{registry ProjectID})"
@@ -68,6 +68,12 @@ type Project @entity {
 
   "Source of the credit data"
   creditDataSource: CreditDataSource!
+}
+
+# Intermediate pointer to allow projects to be referenced by address and tokenId only
+type ProjectByToken @entity {
+  id: ID! # address-tokenId
+  project: Project!
 }
 
 type Country @entity {
@@ -134,10 +140,8 @@ type Purchase @entity {
 
 # Subgraph Versioning
 
-type SubgraphVersion @entity(immutable: true)  {
+type SubgraphVersion @entity(immutable: true) {
   id: ID!
   schemaVersion: String!
   publishedVersion: String!
 }
-
-

--- a/carbonmark/schema.graphql
+++ b/carbonmark/schema.graphql
@@ -87,6 +87,7 @@ type Category @entity {
 enum TokenStandard {
   ERC20
   ERC1155
+  UNKNOWN
 }
 
 type Listing @entity {

--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -38,7 +38,7 @@ export function handleListingCreated(event: ListingCreated): void {
     listing.tokenSymbol = project.id
   } else {
     log.error('Token does not implement ERC20 or ERC1155', [])
-    listing.tokenStandard = 'ERC20'
+    listing.tokenStandard = 'UNKNOWN'
     listing.tokenSymbol = 'Unknown'
   }
 

--- a/carbonmark/src/Carbonmark.ts
+++ b/carbonmark/src/Carbonmark.ts
@@ -38,6 +38,8 @@ export function handleListingCreated(event: ListingCreated): void {
     listing.tokenSymbol = project.id
   } else {
     log.error('Token does not implement ERC20 or ERC1155', [])
+    listing.tokenStandard = 'ERC20'
+    listing.tokenSymbol = 'Unknown'
   }
 
   listing.totalAmountToSell = event.params.amount
@@ -165,7 +167,6 @@ export function handleListingUpdated(event: ListingUpdated): void {
     activity.save()
   }
   listing.save()
-
 }
 
 export function handleListingFilled(event: ListingFilled): void {
@@ -235,7 +236,6 @@ export function handleListingCancelled(event: ListingCancelled): void {
   activity.seller = listing.seller
   activity.save()
 }
-
 
 export function handleSetSubgraphVersion(block: ethereum.Block): void {
   let version = new SubgraphVersion('carbonmark')

--- a/carbonmark/src/CreditManager.ts
+++ b/carbonmark/src/CreditManager.ts
@@ -1,8 +1,6 @@
-import { log,  BigInt } from '@graphprotocol/graph-ts'
-import {
-  CreditAdded as CreditAddedEvent,
-} from '../generated/CreditManager/CreditManager'
-import { Project } from '../generated/schema'
+import { log, BigInt } from '@graphprotocol/graph-ts'
+import { CreditAdded as CreditAddedEvent } from '../generated/CreditManager/CreditManager'
+import { Project, ProjectByToken } from '../generated/schema'
 import { createCategory, createCountry } from './Entities'
 
 export function handleCreditAdded(event: CreditAddedEvent): void {
@@ -12,7 +10,7 @@ export function handleCreditAdded(event: CreditAddedEvent): void {
 
   const id = event.params.projectId + '-' + event.params.vintage
   let project = new Project(id)
-  project.key = event.params.projectId 
+  project.key = event.params.projectId
   project.name = event.params.name
   project.methodology = event.params.methodologies[0]
   project.isExAnte = event.params.isExAnte
@@ -24,6 +22,12 @@ export function handleCreditAdded(event: CreditAddedEvent): void {
   project.country = event.params.country
   project.creditDataSource = 'Event'
   project.save()
+
+  let lookupId = event.params.tokenAddress.toHexString().toLowerCase() + '-' + event.params.tokenId.toString()
+
+  let pbt = new ProjectByToken(lookupId)
+  pbt.project = project.id
+  pbt.save()
 
   createCountry(project.country)
   createCategory(project.category)

--- a/carbonmark/src/Entities.ts
+++ b/carbonmark/src/Entities.ts
@@ -1,4 +1,4 @@
-import { Activity, Category, Country, Listing, Project, Purchase, User } from '../generated/schema'
+import { Activity, Category, Country, Listing, Project, ProjectByToken, Purchase, User } from '../generated/schema'
 import { ZERO_BI } from '../../lib/utils/Decimals'
 import { ZERO_ADDRESS } from '../../lib/utils/Constants'
 import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
@@ -10,8 +10,20 @@ export function loadOrCreateProject(token: Address, tokenId: BigInt): Project {
   let id = ''
   let registry = ''
   let projectIndex = 0
+
+  // check if project already in store by token address and tokenId (from updater tool)
+  let lookupId = tokenAddress.toLowerCase() + '-' + tokenId.toString()
+  let pbt = ProjectByToken.load(lookupId)
+  if (pbt != null) {
+    return Project.load(pbt.project) as Project
+  }
+
+  // if not, search for the project in the PROJECT_INFO array
   for (let i = 0; i < PROJECT_INFO.length; i++) {
-    if (tokenAddress.toLowerCase() == PROJECT_INFO[i].address.toLowerCase() && tokenId.toString() == PROJECT_INFO[i].tokenId) {
+    if (
+      tokenAddress.toLowerCase() == PROJECT_INFO[i].address.toLowerCase() &&
+      tokenId.toString() == PROJECT_INFO[i].tokenId
+    ) {
       id = PROJECT_INFO[i].projectId + '-' + PROJECT_INFO[i].vintage
       registry = PROJECT_INFO[i].projectId.split('-')[0]
       projectIndex = i

--- a/carbonmark/src/Entities.ts
+++ b/carbonmark/src/Entities.ts
@@ -11,14 +11,14 @@ export function loadOrCreateProject(token: Address, tokenId: BigInt): Project {
   let registry = ''
   let projectIndex = 0
 
-  // check if project already in store by token address and tokenId (from updater tool)
+  // check if project already in store by token address and tokenId (via CreditManager)
   let lookupId = tokenAddress.toLowerCase() + '-' + tokenId.toString()
   let pbt = ProjectByToken.load(lookupId)
   if (pbt != null) {
     return Project.load(pbt.project) as Project
   }
 
-  // if not, search for the project in the PROJECT_INFO array
+  // if null, search for the project in the PROJECT_INFO array
   for (let i = 0; i < PROJECT_INFO.length; i++) {
     if (
       tokenAddress.toLowerCase() == PROJECT_INFO[i].address.toLowerCase() &&

--- a/carbonmark/tests/CreditManager.test.ts
+++ b/carbonmark/tests/CreditManager.test.ts
@@ -1,31 +1,38 @@
-import {
-  clearStore,
-  test,
-  describe,
-  newMockEvent,
-  beforeEach,
-  assert,
-} from 'matchstick-as'
+import { clearStore, test, describe, newMockEvent, beforeEach, assert, createMockedFunction } from 'matchstick-as'
+import { BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { Address, ethereum } from '@graphprotocol/graph-ts'
 import { CreditAdded } from '../generated/CreditManager/CreditManager'
+import { ListingCreated } from '../generated/Carbonmark/Carbonmark'
 import { handleCreditAdded } from '../src/CreditManager'
+import { handleListingCreated } from '../src/Carbonmark'
 
+// credit added
 
 const ACTOR_ADDRESS = '0x3Da300661Eb0f04a4044A4fB01d79E66C8c81ED9'
-const ActorAddress=Address.fromString(ACTOR_ADDRESS)
+const ActorAddress = Address.fromString(ACTOR_ADDRESS)
 const TOKEN_ADDRESS = '0xCcAcC6099debD9654C6814fCb800431Ef7549b10'
-const tokenAddress=Address.fromString(TOKEN_ADDRESS)
+const tokenAddress = Address.fromString(TOKEN_ADDRESS)
 const TOKEN_ID = 0
 const IS_EX_ANTE = false
-const PROJECT_ID = 'VCS-191'
-const REGISTRY = 'VCS'
-const VINTAGE = '2009'
-const NAME = '4×50 MW Dayingjiang- 3 Hydropower Project Phases 1&2'
-const METHODOLOGIES = ['ACM0002']
-const CATEGORY = 'Renewable Energy'
-const COUNTRY = 'China'
+const PROJECT_ID = 'POC-999'
+const REGISTRY = 'POC'
+const VINTAGE = '3000'
+const NAME = 'Project that cannot be found in the PROJECT_INFO array'
+const SYMBOL = 'POC-999-3000'
+const METHODOLOGIES = ['ACM0001']
+const CATEGORY = 'Coal Mine'
+const COUNTRY = 'Antartica'
 const REGION = 'unknown'
 const DESCRIPTION = 'description'
+
+// listing
+
+const LISTING_ID = '0x1234567890'
+const SELLER_ADDRESS = '0xAbC1230000000000000000000000000000000000'
+const TOTAL_AMOUNT = BigInt.fromI32(100)
+const UNIT_PRICE = BigInt.fromI32(50)
+const EXPIRATION = BigInt.fromI32(1_763_000_000) // arbitrary
+const MIN_FILL = BigInt.fromI32(1)
 
 export function newCreditAddedEvent(): CreditAdded {
   let mockEvent = newMockEvent()
@@ -66,13 +73,56 @@ export function newCreditAddedEvent(): CreditAdded {
   creditAddedEvent.parameters.push(region)
   creditAddedEvent.parameters.push(description)
 
-
   return creditAddedEvent
 }
 
-describe('CreditManager tests', () => {
+function newListingCreatedEvent(): ListingCreated {
+  let mock = newMockEvent()
+  let listingCreatedEvent = new ListingCreated(
+    Address.fromString(SELLER_ADDRESS),
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  )
+  listingCreatedEvent.parameters = [
+    // assume your event signature is:
+    // event ListingCreated(string id, address seller, address token, uint256 tokenId, uint256 totalAmount, uint256 unitPrice, uint256 expiration, uint256 minFill)
+    new ethereum.EventParam('id', ethereum.Value.fromBytes(Bytes.fromHexString(LISTING_ID))),
+    new ethereum.EventParam('account', ethereum.Value.fromAddress(Address.fromString(SELLER_ADDRESS))),
+    new ethereum.EventParam('token', ethereum.Value.fromAddress(Address.fromString(TOKEN_ADDRESS))),
+    new ethereum.EventParam('tokenId', ethereum.Value.fromI32(TOKEN_ID)),
+    new ethereum.EventParam('price', ethereum.Value.fromUnsignedBigInt(UNIT_PRICE)),
+    new ethereum.EventParam('amount', ethereum.Value.fromUnsignedBigInt(TOTAL_AMOUNT)),
+    new ethereum.EventParam('minFillAmount', ethereum.Value.fromUnsignedBigInt(MIN_FILL)),
+    new ethereum.EventParam('deadline', ethereum.Value.fromUnsignedBigInt(EXPIRATION)),
+  ]
+  return listingCreatedEvent
+}
 
+describe('CreditManager tests', () => {
   beforeEach(() => {
+    // ERC20 mocks
+    createMockedFunction(Address.fromString(TOKEN_ADDRESS), 'name', 'name():(string)').returns([
+      ethereum.Value.fromString(NAME),
+    ])
+
+    createMockedFunction(Address.fromString(TOKEN_ADDRESS), 'symbol', 'symbol():(string)').returns([
+      ethereum.Value.fromString(SYMBOL),
+    ])
+
+    createMockedFunction(Address.fromString(TOKEN_ADDRESS), 'decimals', 'decimals():(uint8)').returns([
+      ethereum.Value.fromI32(18),
+    ])
+
+    // 1155 mocks
+    createMockedFunction(Address.fromString(TOKEN_ADDRESS), 'supportsInterface', 'supportsInterface(bytes4):(bool)')
+      .withArgs([ethereum.Value.fromFixedBytes(Bytes.fromHexString('0xd9b67a26'))])
+      .returns([ethereum.Value.fromBoolean(true)])
+
     clearStore()
   })
 
@@ -93,5 +143,44 @@ describe('CreditManager tests', () => {
     assert.fieldEquals('Project', id, 'category', CATEGORY)
     assert.fieldEquals('Project', id, 'country', COUNTRY)
     assert.fieldEquals('Project', id, 'creditDataSource', 'Event')
+  })
+
+  test('CreditAdded populates Project & ProjectByToken', () => {
+    const creditAddedEvent = newCreditAddedEvent()
+    const id = PROJECT_ID + '-' + VINTAGE
+
+    handleCreditAdded(creditAddedEvent)
+
+    assert.fieldEquals('Project', id, 'key', PROJECT_ID)
+    assert.fieldEquals('Project', id, 'name', NAME)
+    assert.fieldEquals('Project', id, 'methodology', METHODOLOGIES[0])
+    assert.fieldEquals('Project', id, 'isExAnte', 'false')
+    assert.fieldEquals('Project', id, 'vintage', VINTAGE)
+    assert.fieldEquals('Project', id, 'projectAddress', TOKEN_ADDRESS.toLowerCase())
+    assert.fieldEquals('Project', id, 'registry', REGISTRY)
+    assert.fieldEquals('Project', id, 'tokenId', TOKEN_ID.toString())
+    assert.fieldEquals('Project', id, 'category', CATEGORY)
+    assert.fieldEquals('Project', id, 'country', COUNTRY)
+    assert.fieldEquals('Project', id, 'creditDataSource', 'Event')
+
+    assert.fieldEquals('ProjectByToken', TOKEN_ADDRESS.toLowerCase() + '-' + TOKEN_ID.toString(), 'project', id)
+  })
+
+  test('ListingCreated uses that Project from store', () => {
+    handleCreditAdded(newCreditAddedEvent())
+
+    const listingEvent = newListingCreatedEvent()
+    handleListingCreated(listingEvent)
+
+    const projectId = PROJECT_ID + '-' + VINTAGE
+    assert.fieldEquals('Listing', LISTING_ID, 'project', projectId)
+
+    assert.fieldEquals('Listing', LISTING_ID, 'seller', SELLER_ADDRESS.toLowerCase())
+    assert.fieldEquals('Listing', LISTING_ID, 'tokenAddress', TOKEN_ADDRESS.toLowerCase())
+    assert.fieldEquals('Listing', LISTING_ID, 'tokenId', TOKEN_ID.toString())
+    assert.fieldEquals('Listing', LISTING_ID, 'totalAmountToSell', TOTAL_AMOUNT.toString())
+    assert.fieldEquals('Listing', LISTING_ID, 'singleUnitPrice', UNIT_PRICE.toString())
+    assert.fieldEquals('Listing', LISTING_ID, 'expiration', EXPIRATION.toString())
+    assert.fieldEquals('Listing', LISTING_ID, 'minFillAmount', MIN_FILL.toString())
   })
 })

--- a/carbonmark/version.json
+++ b/carbonmark/version.json
@@ -1,1 +1,1 @@
-{"schemaVersion": "1.7.0", "publishedVersion": "1.7.0"}
+{"schemaVersion": "1.7.2", "publishedVersion": "1.7.2"}


### PR DESCRIPTION
## 📄 Description

<!--
Provide a concise description of the changes introduced by this PR.
-->

When the `CreditManager` is used the project with the correct id (`registry-registryId-vintage`) is correctly added to the store. 

However when listings are created the hardcoded `PROJECT_INFO` is still used as the source of truth, not the store directly, so any projects added via CreditManager are not available.

Additionally, when a listing is created only the tokenAddress and tokenId are emitted, so we can't directly load the Project entity (`registry-registryId-vintage`) created by the CreditManager as it will not be in the `PROJECT_INFO` list. 

In order to load the Project entity and not change the Project entity's id, this PR introduces a ProjectByToken entity so we can save that entity on a CreditManager update and use it in `loadOrCreateProject` when creating a listing.


## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->

feat: ProjectByToken entity to enable CreditManager projects in listing


## ✅ Checklist


- [x] Matchstick test included (if applicable).
- [x] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)
- [x] If modifying `polygon-digital-carbon` or `carbonmark` subgraphs, MAKE SURE TO MODIFY `subgraph.template.yaml` (NOT `subgraph.yaml` DIRECTLY!)
  - If modifying `subgraph.template.yaml`, also make sure to run `npm run prepare-matic` locally and commit the resulting rendered `subgraph.yaml`

## ℹ️ Additional Information

<!--
Provide any additional information or context that may be relevant to this PR.
-->

