### PR TITLE
remove --studio flag from deploy CI

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -69,5 +69,5 @@ jobs:
         env:
           REF: ${{ github.ref }}
       - name: Deploy Subgraph to Studio
-        run: ../node_modules/.bin/graph deploy --studio --deploy-key ${{ secrets.SUBGRAPH_STUDIO_DEPLOY_KEY }} ${{ steps.create_subgraph_name.outputs.subgraph }} --version-label ${{ steps.create_subgraph_name.outputs.short_sha }}
+        run: ../node_modules/.bin/graph deploy --deploy-key ${{ secrets.SUBGRAPH_STUDIO_DEPLOY_KEY }} ${{ steps.create_subgraph_name.outputs.subgraph }} --version-label ${{ steps.create_subgraph_name.outputs.short_sha }}
         working-directory: '${{ matrix.subgraph }}'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -102,7 +102,7 @@ jobs:
         env:
           DEPLOY_KEY: ${{ secrets.SUBGRAPH_STUDIO_DEPLOY_KEY }}
         run: |
-          ../node_modules/.bin/graph deploy --studio \
+          ../node_modules/.bin/graph deploy \
             --deploy-key "$DEPLOY_KEY" \
             "${{ steps.slug.outputs.slug }}" \
             --version-label "${{ steps.version.outputs.version }}"


### PR DESCRIPTION
This flag was deprecated in 0.88.0

https://github.com/graphprotocol/graph-tooling/blob/main/packages/cli/CHANGELOG.md#0880

I will create an issue as we still need to remove useage of `--product` flag from our package.json commands, I am just not sure what the replacement is yet.