### PR TITLE
[`GHA`] Fix check-version

### DIFF
--- a/pairs/src/Pair.ts
+++ b/pairs/src/Pair.ts
@@ -289,14 +289,14 @@ export function handleSwap(event: SwapEvent): void {
     pair.totalvolume = pair.totalvolume.plus(swap.volume)
     pair.totalklimaearnedfees = pair.totalklimaearnedfees.plus(swap.klimaearnedfees)
     pair.lastupdate = hour_timestamp
-
+    
     let reserves = contract.getReserves()
     pair.reserve0 = toUnits(reserves.value0, token0_decimals)
     pair.reserve1 = toUnits(reserves.value1, token1_decimals)
     pair.reserve0Raw = reserves.value0
     pair.reserve1Raw = reserves.value1
     pair.reservesLastUpdate = hour_timestamp
-
+    
     pair.save()
   }
   if (event.address == KLIMA_USDC_PAIR) {
@@ -377,14 +377,14 @@ export function handleSwap(event: SwapEvent): void {
     pair.totalvolume = pair.totalvolume.plus(swap.volume)
     pair.totalklimaearnedfees = pair.totalklimaearnedfees.plus(swap.klimaearnedfees)
     pair.lastupdate = hour_timestamp
-
+    
     let reserves = contract.getReserves()
     pair.reserve0 = toUnits(reserves.value0, token0_decimals)
     pair.reserve1 = toUnits(reserves.value1, token1_decimals)
     pair.reserve0Raw = reserves.value0
     pair.reserve1Raw = reserves.value1
     pair.reservesLastUpdate = hour_timestamp
-
+    
     pair.save()
   }
 }


### PR DESCRIPTION
## 📄 Description

Previous version used GITHUB_ENV flags. If conditions are evaluated, and steps queued, before those flags exist so those steps did not run and thus no version changes were detected.

Replaced GITHUB_ENV flags with step outputs (GITHUB_OUTPUT).

Outputs are available to later if: conditions, so check-version will now fails when changes exist but the package version isn’t bumped.

## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->

chore: fix check-version gha


## ✅ Checklist


- [x] Matchstick test included (if applicable).
- [x] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)
- [x] If modifying `polygon-digital-carbon` or `carbonmark` subgraphs, MAKE SURE TO MODIFY `subgraph.template.yaml` (NOT `subgraph.yaml` DIRECTLY!)
  - If modifying `subgraph.template.yaml`, also make sure to run `npm run prepare-matic` locally and commit the resulting rendered `subgraph.yaml`

