### PR TITLE
[`GHA`] Add EBC to no prefix list

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Derive subgraph slug
         id: slug
         run: |
-          if [[ "${{ matrix.subgraph }}" == "polygon-digital-carbon" || "${{ matrix.subgraph }}" == "celo-bridged-carbon" ]]; then
+          if [[ "${{ matrix.subgraph }}" == "polygon-digital-carbon" || "${{ matrix.subgraph }}" == "celo-bridged-carbon" || "${{ matrix.subgraph }}" == "ethereum-bridged-carbon" ]]; then
             echo "slug=${{ matrix.subgraph }}" >> "$GITHUB_OUTPUT"
           else
             echo "slug=klimadao-${{ matrix.subgraph }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 📄 Description

Deploy job is erroring as `klimadao-` is being appended to `ethereum-bridged-carbon` which errors on the graph deploy as that subgraph has no prefix. Adding it to the no prefix list so the graph can correctly find it.

## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->

chore: add `ethereum-bridged-carbon` to no prefix list


## ✅ Checklist


- [x] Matchstick test included (if applicable).
- [x] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)
- [x] If modifying `polygon-digital-carbon` or `carbonmark` subgraphs, MAKE SURE TO MODIFY `subgraph.template.yaml` (NOT `subgraph.yaml` DIRECTLY!)
  - If modifying `subgraph.template.yaml`, also make sure to run `npm run prepare-matic` locally and commit the resulting rendered `subgraph.yaml`


