### PR TITLE
Feat/toucan certificate ids

### DIFF
--- a/polygon-digital-carbon/package.json
+++ b/polygon-digital-carbon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polygon-digital-carbon",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "repository": "https://github.com/KlimaDAO/klima-subgraphs/polygon-carbon",
   "license": "MIT",
   "scripts": {

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -404,7 +404,6 @@ type Retire @entity(immutable: false) {
   "Additional data for async retirements. Currently C3 retires, ECO & J-Credit, and puro.earth"
   asyncRetireRequest: AsyncRetireRequest
 
-  "Retirement certificate/NFT id recovered at async finalization (e.g. Toucan). Set separately from retirementTokenId, which is populated synchronously by registries like ICR."
   certificate: RetirementCertificate @derivedFrom(field: "retire")
 }
 
@@ -540,7 +539,7 @@ type C3RetireRequestDetails @entity(immutable: false) {
   retirementMetadata: C3RetirementMetadata
 }
 
-"On-chain retirement certificate/NFT id for an async (request/finalize) retirement. Created at finalization once the certificate is minted, keyed by the parent Retire's id. Kept separate from Retire.retirementTokenId so the synchronous ICR path is unaffected."
+"On-chain retirement certificate/NFT id, keyed by the parent Retire's id. Populated across all registries: synchronously for ICR (where it mirrors Retire.retirementTokenId) and at async finalization for Toucan once the certificate is minted. Kept as a separate entity so consumers can rely on a single field regardless of sync vs async path."
 type RetirementCertificate @entity(immutable: true) {
   "Same id as the parent Retire"
   id: Bytes!

--- a/polygon-digital-carbon/schema.graphql
+++ b/polygon-digital-carbon/schema.graphql
@@ -403,6 +403,9 @@ type Retire @entity(immutable: false) {
 
   "Additional data for async retirements. Currently C3 retires, ECO & J-Credit, and puro.earth"
   asyncRetireRequest: AsyncRetireRequest
+
+  "Retirement certificate/NFT id recovered at async finalization (e.g. Toucan). Set separately from retirementTokenId, which is populated synchronously by registries like ICR."
+  certificate: RetirementCertificate @derivedFrom(field: "retire")
 }
 
 type KlimaRetire @entity(immutable: false) {
@@ -535,6 +538,15 @@ type C3RetireRequestDetails @entity(immutable: false) {
   c3OffsetNftIndex: BigInt!
   tokenURI: String!
   retirementMetadata: C3RetirementMetadata
+}
+
+"On-chain retirement certificate/NFT id for an async (request/finalize) retirement. Created at finalization once the certificate is minted, keyed by the parent Retire's id. Kept separate from Retire.retirementTokenId so the synchronous ICR path is unaffected."
+type RetirementCertificate @entity(immutable: true) {
+  "Same id as the parent Retire"
+  id: Bytes!
+  retire: Retire!
+  "The retirement NFT id, emitted in the CertificateMinted event"
+  retirementTokenId: BigInt!
 }
 
 ##############################

--- a/polygon-digital-carbon/src/RetirementHandler.ts
+++ b/polygon-digital-carbon/src/RetirementHandler.ts
@@ -28,7 +28,7 @@ import { loadOrCreateCarbonProject } from './utils/CarbonProject'
 import { loadRetire, saveRetire } from './utils/Retire'
 import { Bytes, log } from '@graphprotocol/graph-ts'
 import { loadOrCreateC3RetireRequestDetails, loadC3RetireRequestDetails } from './utils/C3'
-import { Token, TokenURISafeguard } from '../generated/schema'
+import { RetirementCertificate, Token, TokenURISafeguard } from '../generated/schema'
 import { createAsyncRetireRequestId } from '../utils/helpers'
 import { AsyncRetireRequestStatus } from '../utils/enums'
 import { loadAsyncRetireRequest, loadOrCreateAsyncRetireRequest } from './utils/AsyncRetireRequest'
@@ -293,6 +293,15 @@ export function handleReturnedPoccID(event: returnedPoccID): void {
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements - 1))
   retire.retirementTokenId = event.params.poccID
   retire.save()
+
+  // save on retirementCertificate entity
+  let retirementCertificate = RetirementCertificate.load(retire.id)
+  if (retirementCertificate == null) {
+    retirementCertificate = new RetirementCertificate(retire.id)
+    retirementCertificate.retire = retire.id
+    retirementCertificate.retirementTokenId = event.params.poccID
+    retirementCertificate.save()
+  }
 }
 
 export function saveICRRetirement(event: RetiredVintage): void {
@@ -333,6 +342,14 @@ export function saveICRRetirement(event: RetiredVintage): void {
   let retire = loadRetire(sender.id.concatI32(sender.totalRetirements))
   retire.retirementTokenId = event.params.nftTokenId
   retire.save()
+
+  let retirementCertificate = RetirementCertificate.load(retire.id)
+  if (retirementCertificate == null) {
+    retirementCertificate = new RetirementCertificate(retire.id)
+    retirementCertificate.retire = retire.id
+    retirementCertificate.retirementTokenId = event.params.nftTokenId
+    retirementCertificate.save()
+  }
 
   incrementAccountRetirements(senderAddress)
 }

--- a/polygon-digital-carbon/src/TransferHandler.ts
+++ b/polygon-digital-carbon/src/TransferHandler.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, Bytes, store } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt, Bytes, ethereum, store } from '@graphprotocol/graph-ts'
 import {
   CCO2_ERC20_CONTRACT,
   ICR_MIGRATION_BLOCK,
@@ -28,7 +28,7 @@ import {
   saveToucanRetirement_1_4_0,
 } from './RetirementHandler'
 import { saveBridge } from './utils/Bridge'
-import { CarbonCredit, CrossChainBridge } from '../generated/schema'
+import { CarbonCredit, CrossChainBridge, RetirementCertificate } from '../generated/schema'
 import { checkForCarbonPoolSnapshot, loadOrCreateCarbonPool } from './utils/CarbonPool'
 import { checkForCarbonPoolCreditSnapshot } from './utils/CarbonPoolCreditBalance'
 import { loadOrCreateEcosystem } from './utils/Ecosystem'
@@ -112,6 +112,31 @@ export function handleToucanPuroRetirementRequested(event: RetirementRequested):
   saveToucanPuroRetirementRequest(event)
 }
 
+// keccak256("CertificateMinted(uint256)") emitted by the Toucan RetirementCertificates contract.
+// The retirement NFT tokenId is not part of the RetirementFinalized event, so we recover it from the receipt.
+const CERTIFICATE_MINTED_TOPIC0 = Bytes.fromHexString(
+  '0x54b249c3cd4a5f80e81d2ad036b251d58d8f5482a926f25d12eabec192cf1ecd'
+)
+
+// Finalization mints the retirement certificate NFT (CertificateMinted) in the same transaction,
+// immediately before RetirementFinalized. Walk the receipt logs backward to find the nearest
+// preceding CertificateMinted and decode its non-indexed uint256 tokenId. Returns zero when unavailable.
+function findRetirementNftId(event: RetirementFinalized): BigInt {
+  let receipt = event.receipt
+  if (receipt == null) return ZERO_BI
+
+  let logs = receipt.logs
+  for (let i = logs.length - 1; i >= 0; i--) {
+    let txLog = logs[i]
+    if (txLog.logIndex.ge(event.logIndex)) continue // only logs before this one
+    if (txLog.topics.length > 0 && txLog.topics[0].equals(CERTIFICATE_MINTED_TOPIC0)) {
+      let decoded = ethereum.decode('uint256', txLog.data)
+      if (decoded) return decoded.toBigInt()
+    }
+  }
+  return ZERO_BI
+}
+
 export function handleToucanPuroRetirementFinalized(event: RetirementFinalized): void {
   let requestId = createAsyncRetireRequestId(event.address, event.params.requestId)
 
@@ -123,6 +148,16 @@ export function handleToucanPuroRetirementFinalized(event: RetirementFinalized):
     let retire = loadRetire(request.retire)
     retire.asyncRetireStatus = AsyncRetireRequestStatus.FINALIZED
     retire.save()
+
+    // Record the minted certificate id in a sidecar entity keyed by the Retire id,
+    // leaving retire.retirementTokenId (used by the synchronous ICR path) untouched.
+    let retirementNftId = findRetirementNftId(event)
+    if (retirementNftId.gt(ZERO_BI)) {
+      let certificate = new RetirementCertificate(retire.id)
+      certificate.retire = retire.id
+      certificate.retirementTokenId = retirementNftId
+      certificate.save()
+    }
   }
 }
 

--- a/polygon-digital-carbon/subgraph.template.yaml
+++ b/polygon-digital-carbon/subgraph.template.yaml
@@ -689,6 +689,7 @@ templates:
           handler: handleToucanPuroRetirementRequested
         - event: RetirementFinalized(indexed uint256)
           handler: handleToucanPuroRetirementFinalized
+          receipt: true
         - event: RetirementReverted(indexed uint256)
           handler: handleToucanPuroRetirementReverted
         - event: Transfer(indexed address,indexed address,uint256)

--- a/polygon-digital-carbon/subgraph.yaml
+++ b/polygon-digital-carbon/subgraph.yaml
@@ -689,6 +689,7 @@ templates:
           handler: handleToucanPuroRetirementRequested
         - event: RetirementFinalized(indexed uint256)
           handler: handleToucanPuroRetirementFinalized
+          receipt: true
         - event: RetirementReverted(indexed uint256)
           handler: handleToucanPuroRetirementReverted
         - event: Transfer(indexed address,indexed address,uint256)


### PR DESCRIPTION
# Pull Request Template

## 📄 Description

Same underlying `RetirementCerificate` logic as https://github.com/Carbonmark/cm-subgraphs/pull/138

In order to avoid a breaking change, retirementTokenId remains on the Retirement entity for now (although it is redundant) and new ICR RetirementCertificate entities are created. 

Once the api is updated we can remove the redundant `Retirement.retirementTokenId` in a future major update (or just leave it).

test sync: https://api.studio.thegraph.com/query/28985/klima-subgraphs-testing/version/latest

## 📝 Changelog

<!--
**Required**: List all changes using Conventional Commit syntax.
Each entry should start with a type, followed by a colon and a brief description.
These entries will be scraped and included in the release tags.

**Example:**
- `feat: add user authentication module`
- `fix: resolve login issue with special characters`
- `docs: update API usage documentation`
- `perf: improve performance of the login endpoint`
- `test: add unit tests for the authentication module`
- `chore: update dependencies`
- `refactor(carbonProjects)!: removed very important field from entity`

Major changes should be marked with `!` and have a footer the `BREAKING CHANGE:` keyword.

docs: https://www.conventionalcommits.org/en/v1.0.0/#summary

ex: - refactor(carbonProjects)!: removed very important field from entity
-->

feat: index toucan cert ids.


## ✅ Checklist


- [x] Matchstick test included (if applicable).
- [x] Version incremented in package.json of the applicable subgraph(s)
- [x] All changes are reflected in the changelog of this PR for the applicable subgraph(s)
- [x] If modifying `polygon-digital-carbon` or `carbonmark` subgraphs, MAKE SURE TO MODIFY `subgraph.template.yaml` (NOT `subgraph.yaml` DIRECTLY!)
  - If modifying `subgraph.template.yaml`, also make sure to run `npm run prepare-matic` locally and commit the resulting rendered `subgraph.yaml`

